### PR TITLE
Fix statistics display for nested worker classes

### DIFF
--- a/lib/sidekiq/statistic/base.rb
+++ b/lib/sidekiq/statistic/base.rb
@@ -1,6 +1,8 @@
 module Sidekiq
   module Statistic
     class Base
+      KEY_SEPARATOR = /(?<!:):(?!:)/.freeze
+
       def initialize(days_previous, start_date = nil)
         @start_date = start_date || Time.now.utc.to_date
         @end_date = @start_date - days_previous
@@ -29,7 +31,7 @@ module Sidekiq
         conn
           .hgetall(REDIS_HASH)
           .each do |keys, value|
-            *keys, last = keys.split(':'.freeze)
+            *keys, last = keys.split(KEY_SEPARATOR)
             keys.inject(redis_hash, &key_or_empty_hash)[last.to_sym] = to_number(value)
           end
       end

--- a/lib/sidekiq/statistic/statistic/realtime.rb
+++ b/lib/sidekiq/statistic/statistic/realtime.rb
@@ -20,7 +20,7 @@ module Sidekiq
           conn
             .hgetall("#{REDIS_HASH}:realtime:#{Time.now.sec - 1}")
             .each do |keys, value|
-              *keys, last = keys.split(':'.freeze)
+              *keys, last = keys.split(KEY_SEPARATOR)
               keys.inject(redis_hash, &key_or_empty_hash)[last] = value.to_i
             end
 

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -26,6 +26,12 @@ class ActiveJobWrapper
   include Sidekiq::Worker
 end
 
+module Nested
+  class HistoryWorker
+    include Sidekiq::Worker
+  end
+end
+
 def middlewared(worker_class = HistoryWorker, msg = {})
   middleware = Sidekiq::Statistic::Middleware.new
   middleware.call worker_class.new, msg, 'default' do

--- a/test/test_sidekiq/statistic_test.rb
+++ b/test/test_sidekiq/statistic_test.rb
@@ -77,6 +77,13 @@ module Sidekiq
             assert_equal 0, count[:failure]
           end
         end
+
+        it 'returns proper stats for nested workers' do
+          middlewared(Nested::HistoryWorker) {}
+
+          count = statistic.number_of_calls('Nested::HistoryWorker')
+          assert_equal 1, count[:total]
+        end
       end
     end
   end


### PR DESCRIPTION
This fixes issue #46, where statistics are parsed improperly if a worker class is nested in a module or class, eg. `Nested::HistoryWorker`.