### PR TITLE
Fix worker's per day stats

### DIFF
--- a/lib/sidekiq/statistic/statistic/runtime.rb
+++ b/lib/sidekiq/statistic/statistic/runtime.rb
@@ -44,6 +44,7 @@ module Sidekiq
 
       def values(key)
         @values ||= @redis_statistic.statistic_for(@worker)
+        @values = @values.is_a?(Array) ? @values : [@values]
         @values.map{ |s| s[key] }.compact
       end
     end

--- a/lib/sidekiq/statistic/statistic/workers.rb
+++ b/lib/sidekiq/statistic/statistic/workers.rb
@@ -34,9 +34,9 @@ module Sidekiq
       end
 
       def runtime_for_day(worker_name, worker_data)
-        runtime_statistic(worker_name, worker_data[:runtime])
+        runtime_statistic(worker_name, worker_data)
           .values_hash
-          .merge!(last: worker_data[:last_runtime])
+          .merge!(last: worker_data[:last_time])
       end
 
       def number_of_calls(worker)


### PR DESCRIPTION
Hi guys. I've found some problems with 'per day' statistics:
<img width="1201" alt="screen shot 2015-10-17 at 21 41 06" src="https://cloud.githubusercontent.com/assets/741276/10559371/712c4b7e-7519-11e5-9e83-ba8481bc06b5.png">

as you see these columns: *time, avg, min, max, last_run* contain incorrect data (just the same data in every row). I've tried to fix it, so you can see now some changes:
<img width="1194" alt="screen shot 2015-10-17 at 21 41 53" src="https://cloud.githubusercontent.com/assets/741276/10559379/9901aa04-7519-11e5-8873-e0d4ffa066d3.png">

The values from the table are the same as data from my redis db. Much better.