### PR TITLE
Improve configuration and parse last lines of log file

### DIFF
--- a/lib/sidekiq/statistic/configuration.rb
+++ b/lib/sidekiq/statistic/configuration.rb
@@ -1,10 +1,11 @@
 module Sidekiq
   module Statistic
     class Configuration
-      attr_accessor :log_file
+      attr_accessor :log_file, :log_file_lines_count
 
       def initialize
         @log_file = 'log/sidekiq.log'
+        @log_file_lines_count = 1000
       end
     end
   end

--- a/lib/sidekiq/statistic/log_parser.rb
+++ b/lib/sidekiq/statistic/log_parser.rb
@@ -14,7 +14,7 @@ module Sidekiq
 
         File
           .readlines(@logfile)
-          .first(FILE_LINES_COUNT)
+          .last(FILE_LINES_COUNT)
           .map{ |line| sub_line(line) if line[/\W?#@worker_name\W?/] }
           .compact
       end

--- a/lib/sidekiq/statistic/log_parser.rb
+++ b/lib/sidekiq/statistic/log_parser.rb
@@ -3,7 +3,6 @@ module Sidekiq
     # Heroku have read only file system. See more in this link:
     # https://devcenter.heroku.com/articles/read-only-filesystem
     class LogParser
-      FILE_LINES_COUNT = 1_000
       def initialize(worker_name)
         @worker_name = worker_name
         @logfile = log_file
@@ -14,7 +13,7 @@ module Sidekiq
 
         File
           .readlines(@logfile)
-          .last(FILE_LINES_COUNT)
+          .last(log_file_lines_count)
           .map{ |line| sub_line(line) if line[/\W?#@worker_name\W?/] }
           .compact
       end
@@ -51,6 +50,10 @@ module Sidekiq
         Sidekiq.options[:logfile] ||
           Sidekiq.logger.instance_variable_get(:@logdev).filename ||
           Sidekiq::Statistic.configuration.log_file
+      end
+
+      def log_file_lines_count
+        Sidekiq::Statistic.configuration.log_file_lines_count
       end
     end
   end

--- a/lib/sidekiq/statistic/version.rb
+++ b/lib/sidekiq/statistic/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Statistic
-    VERSION = '1.2.1'
+    VERSION = '1.2.0'
   end
 end

--- a/lib/sidekiq/statistic/version.rb
+++ b/lib/sidekiq/statistic/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Statistic
-    VERSION = '1.2.0'
+    VERSION = '1.2.1'
   end
 end

--- a/test/test_sidekiq/log_parser_test.rb
+++ b/test/test_sidekiq/log_parser_test.rb
@@ -20,6 +20,13 @@ module Sidekiq
 
             assert_equal result, log_parser.parse
           end
+
+          it 'returns array with last <log_file_lines_count> lines' do
+            Sidekiq::Statistic.configuration.log_file_lines_count = 1
+
+            result = ["HistoryWorker (fail) <span class=\"statistic__jid js-jid__219f4e9b9013bfec76faa270\"data-target=\".js-jid__219f4e9b9013bfec76faa270\" style=\"background-color: rgba(116,63,167,0.2);\">JID-219f4e9b9013bfec76faa270</span>"]
+            assert_equal  result, log_parser.parse
+          end
         end
 
         describe 'when worker don\'t called' do


### PR DESCRIPTION
It is better to parse tail of sidekiq log file because all new jobs are there.