### PR TITLE
support negative numbers + fix for converting integers

### DIFF
--- a/lib/sidekiq/statistic/base.rb
+++ b/lib/sidekiq/statistic/base.rb
@@ -56,7 +56,7 @@ module Sidekiq
 
       def to_number(value)
         case value
-        when /\A-?[\d.]+\z/ then value.to_f
+        when /\A-?\d+\.\d+\z/ then value.to_f
         when /\A-?\d+\z/ then value.to_i
         else value
         end

--- a/lib/sidekiq/statistic/base.rb
+++ b/lib/sidekiq/statistic/base.rb
@@ -56,8 +56,8 @@ module Sidekiq
 
       def to_number(value)
         case value
-        when /\A[\d.]+\z/ then value.to_f
-        when /\A\d+\z/ then value.to_i
+        when /\A-?[\d.]+\z/ then value.to_f
+        when /\A-?\d+\z/ then value.to_i
         else value
         end
       end


### PR DESCRIPTION
Hi,

This pull request does the following fixes to `to_number()` function:
* correctly process negative numbers
* process integers as integers (they are always processed as floats now) -- I don't know the impact of this point so please let me know if you want to pull only the first commit

Could not run tests but in my setup I see the statistics working fine.


A bit of background so that you understand the intent of the fix better:

Recently we've started to see 500 errors when accessing `/sidekiq/statistic` with no error messages in logs.

After digging through the code I've found that my Redis holds a single broken statistics entry for Sidekiq which caused crashes:
```ruby
["2016-07-20:NotificationWorker:min_time", "-162.529"]
```

Don't know how that value got into the Redis DB.
Anyway I believe this should not cause application to crash hence the fix.
