### PR TITLE
remove sinatra dependency, add tilt dependency

### DIFF
--- a/sidekiq-statistic.gemspec
+++ b/sidekiq-statistic.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake', '~> 0'
   gem.add_development_dependency 'mocha', '~> 0'
   gem.add_development_dependency 'rack-test', '~> 0'
+  gem.add_development_dependency 'rack', '~> 1.6.4'
   gem.add_development_dependency 'minitest', '~> 5.0', '>= 5.0.7'
   gem.add_development_dependency 'minitest-utils', '~> 0'
 end

--- a/sidekiq-statistic.gemspec
+++ b/sidekiq-statistic.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'sidekiq', '>= 3.3.4', '< 5'
+  gem.add_dependency 'tilt', '~> 2.0'
 
   gem.add_development_dependency 'rake', '~> 0'
-  gem.add_development_dependency 'sinatra', '~> 1.4.6'
   gem.add_development_dependency 'mocha', '~> 0'
   gem.add_development_dependency 'rack-test', '~> 0'
   gem.add_development_dependency 'minitest', '~> 5.0', '>= 5.0.7'


### PR DESCRIPTION
tilt is required [here](https://github.com/davydovanton/sidekiq-statistic/blob/6f3e4f59b32e5537cb04987b5a69827d349fa8fa/lib/sidekiq/statistic/web_extension.rb#L1)  (`require 'tilt/erb'`) but it's missing from the gemspec. tilt used to be brought in via the sinatra dependency. sidekiq 4.2.0 removed the sinatra dependency so tilt should probably be added to the gemspec.

Without this change users of this gem and sidekiq 4.2 will have to explicitly declare a tilt dependency in their Gemfile.
