### PR TITLE
Limit the number of entries in timeslist.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## HEAD
+* 30.03.2017: Prevent excessive Redis memory usage  *Gareth du Plooy*
 * 08.04.2016: Add new option fir displaying last N lines of log file (#91) *Nick Zhebrun*
 * 20.11.2015: Convert value in redis time array to float (#76) *Anton Davydov*
 * 20.11.2015: Add Ukrainian Localization (#85) *@POStroi*

--- a/lib/sidekiq/statistic/configuration.rb
+++ b/lib/sidekiq/statistic/configuration.rb
@@ -1,11 +1,12 @@
 module Sidekiq
   module Statistic
     class Configuration
-      attr_accessor :log_file, :last_log_lines
+      attr_accessor :log_file, :last_log_lines, :max_timelist_length
 
       def initialize
         @log_file = 'log/sidekiq.log'
         @last_log_lines = 1_000
+        @max_timelist_length = 250_000
       end
     end
   end

--- a/test/test_sidekiq/configuration_test.rb
+++ b/test/test_sidekiq/configuration_test.rb
@@ -17,6 +17,14 @@ module Sidekiq
           assert_equal 'test/sidekiq.log', config.log_file
         end
       end
+
+      describe '#max_timelist_length=' do
+        it 'can set value' do
+          config = Configuration.new
+          config.max_timelist_length = 12345
+          assert_equal 12345, config.max_timelist_length
+        end
+      end
     end
   end
 end

--- a/test/test_sidekiq/middleware_test.rb
+++ b/test/test_sidekiq/middleware_test.rb
@@ -1,4 +1,5 @@
 require 'minitest_helper'
+require 'mocha/setup'
 
 module Sidekiq
   module Statistic
@@ -70,6 +71,16 @@ module Sidekiq
         workers.each(&:join)
 
         assert_equal 500, actual['HistoryWorker'][:passed]
+      end
+
+      it 'removes 1/4 the timelist entries after crossing max_timelist_length' do
+        workers = []
+        Sidekiq::Statistic.configuration.max_timelist_length = 10
+        11.times do
+          middlewared {}
+        end
+
+        assert_equal 8, Sidekiq.redis { |conn| conn.llen("#{Time.now.strftime "%Y-%m-%d"}:HistoryWorker:timeslist") }
       end
 
       it 'supports ActiveJob workers' do


### PR DESCRIPTION
Trying to address the performance issues noted in https://github.com/davydovanton/sidekiq-statistic/issues/73 and https://github.com/davydovanton/sidekiq-statistic/issues/72.

Thinking about a solution for this, I tried to consider the following:

- Solves the memory issue in a reasonable way without adding complexity.
- Doesn't require a ton of changes to the library.
- Doesn't cause complete flushes of usage stats at random times resulting in invalid timing data when viewing your job stats.
- Doesn't introduce new performance issues.

The solution I came up with here is to simply select a threshold for the number of jobs we want to sample timing data for and once we cross that threshold, safely remove the oldest (_very arbitrary_) 1/4 of the timing values in the list. Note that this **does not affect any job status counts whatsoever**, but rather the  average, max, min, and total processing time displayed with each job.
If this sounds concerning consider that:
- This type of roll-up [already occurs](https://github.com/davydovanton/sidekiq-statistic/blob/master/lib/sidekiq/statistic/base.rb#L70) when you simply view the Sidekiq statistics dashboard. If you run a bunch of jobs, visit the dashboard, and note the `Time(sec)` value for your job. This is supposed to be total run time of all instances of that job. Run a few  more jobs and refresh, you'll see these timing metrics basically start to count again from zero.

- The default is 250,000 jobs of the most recent jobs of any specific job type, is scoped at the job level, and is configurable. It's a fairly large default that shouldn't be hit for most people, and will consume max about 3.5MB per job type per day, which IMO is pretty reasonable.

Through some local and anecdotal testing, pushing 500,000 numbers into a list in Redis via lpush as we do via `redis.lpush "#{worker_key}:timeslist", status[:time]` consumes about 7 MB. Doesn't seem like much but for those [having issues](https://github.com/davydovanton/sidekiq-statistic/issues/72#issuecomment-139155804), pushing > 2M jobs per day, that's a minimum of 28 MB per day, and in only a few weeks you're over 1 GB of memory usage you won't get back.

I'll add more test results below, but initial testing shows this does fix the issue.

Thanks @davydovanton for this gem, it's the best one I've found for viewing and tracking Sidekiq history. 
