### PR TITLE
Use frozen_string_literal comment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ before_install:
   - gem install bundler
   - gem update bundler
 rvm:
-  - 2.2.4
-  - 2.3.0
-  - 2.4.0
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
   - jruby-head
   - rbx-2
 matrix:

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,6 @@
 #!/usr/bin/env rake
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "sidekiq/history"
+require "sidekiq/statistic"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/sidekiq-statistic.rb
+++ b/lib/sidekiq-statistic.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'sidekiq/statistic'

--- a/lib/sidekiq/statistic.rb
+++ b/lib/sidekiq/statistic.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require 'sidekiq/web'
 rescue LoadError
@@ -20,7 +22,7 @@ require 'sidekiq/statistic/web_extension_helper'
 
 module Sidekiq
   module Statistic
-    REDIS_HASH = 'sidekiq:statistic'.freeze
+    REDIS_HASH = 'sidekiq:statistic'
 
     class << self
       attr_writer :configuration

--- a/lib/sidekiq/statistic/base.rb
+++ b/lib/sidekiq/statistic/base.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 module Sidekiq
   module Statistic
     class Base
-      KEY_SEPARATOR = /(?<!:):(?!:)/.freeze
+      KEY_SEPARATOR = /(?<!:):(?!:)/
 
       def initialize(days_previous, start_date = nil)
         @start_date = start_date || Time.now.utc.to_date
@@ -41,7 +43,7 @@ module Sidekiq
       end
 
       def desired_dates
-        (@end_date..@start_date).map { |date| date.strftime "%Y-%m-%d".freeze }
+        (@end_date..@start_date).map { |date| date.strftime "%Y-%m-%d" }
       end
 
       def result_hash(redis_hash, key)

--- a/lib/sidekiq/statistic/configuration.rb
+++ b/lib/sidekiq/statistic/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sidekiq
   module Statistic
     class Configuration

--- a/lib/sidekiq/statistic/log_parser.rb
+++ b/lib/sidekiq/statistic/log_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sidekiq
   module Statistic
     # Heroku have read only file system. See more in this link:

--- a/lib/sidekiq/statistic/middleware.rb
+++ b/lib/sidekiq/statistic/middleware.rb
@@ -1,25 +1,27 @@
+# frozen_string_literal: true
+
 module Sidekiq
   module Statistic
     class Middleware
       attr_accessor :msg
 
       def call(worker, msg, queue)
-        worker_status = { last_job_status: 'passed'.freeze }
+        worker_status = { last_job_status: 'passed' }
         start = Time.now
 
         yield
       rescue => e
-        worker_status[:last_job_status] = 'failed'.freeze
+        worker_status[:last_job_status] = 'failed'
 
         raise e
       ensure
         finish = Time.now
-        worker_status[:queue] = msg['queue'.freeze]
+        worker_status[:queue] = msg['queue']
         worker_status[:last_runtime] = finish.utc
         worker_status[:time] = (finish - start).to_f.round(3)
-        worker_status[:class] = msg['wrapped'.freeze] || worker.class.to_s
-        if worker_status[:class] == 'ActionMailer::DeliveryJob'.freeze
-          worker_status[:class] = msg['args'.freeze].first['arguments'.freeze].first
+        worker_status[:class] = msg['wrapped'] || worker.class.to_s
+        if worker_status[:class] == 'ActionMailer::DeliveryJob'
+          worker_status[:class] = msg['args'].first['arguments'].first
         end
 
         save_entry_for_worker worker_status

--- a/lib/sidekiq/statistic/statistic/charts.rb
+++ b/lib/sidekiq/statistic/statistic/charts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sidekiq
   module Statistic
     class Charts < Base

--- a/lib/sidekiq/statistic/statistic/realtime.rb
+++ b/lib/sidekiq/statistic/statistic/realtime.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sidekiq
   module Statistic
     class Realtime < Base
@@ -5,7 +7,7 @@ module Sidekiq
 
       def self.charts_initializer
         workers = new.worker_names.map{ |w| Array.new(12, 0).unshift(w) }
-        workers << Array.new(12) { |i| (Time.now - i).strftime('%T'.freeze) }.unshift('x'.freeze)
+        workers << Array.new(12) { |i| (Time.now - i).strftime('%T') }.unshift('x')
         workers
       end
 
@@ -30,8 +32,8 @@ module Sidekiq
 
       def statistic(params = {})
         {
-          failed: { columns: columns_for('failed'.freeze, params) },
-          passed: { columns: columns_for('passed'.freeze, params) }
+          failed: { columns: columns_for('failed', params) },
+          passed: { columns: columns_for('passed', params) }
         }
       end
 
@@ -50,7 +52,7 @@ module Sidekiq
       end
 
       def axis_array
-        @array ||= ['x', Time.now.strftime('%T'.freeze)]
+        @array ||= ['x', Time.now.strftime('%T')]
       end
     end
   end

--- a/lib/sidekiq/statistic/statistic/runtime.rb
+++ b/lib/sidekiq/statistic/statistic/runtime.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sidekiq
   module Statistic
     class Runtime

--- a/lib/sidekiq/statistic/statistic/workers.rb
+++ b/lib/sidekiq/statistic/statistic/workers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sidekiq
   module Statistic
     class Workers < Base

--- a/lib/sidekiq/statistic/version.rb
+++ b/lib/sidekiq/statistic/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sidekiq
   module Statistic
     VERSION = '1.3.0'

--- a/lib/sidekiq/statistic/web_api_extension.rb
+++ b/lib/sidekiq/statistic/web_api_extension.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 
 module Sidekiq

--- a/lib/sidekiq/statistic/web_extension.rb
+++ b/lib/sidekiq/statistic/web_extension.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tilt/erb'
 require 'json'
 

--- a/lib/sidekiq/statistic/web_extension_helper.rb
+++ b/lib/sidekiq/statistic/web_extension_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 
 module Sidekiq

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 Encoding.default_external = Encoding::UTF_8

--- a/test/test_sidekiq/base_statistic_test.rb
+++ b/test/test_sidekiq/base_statistic_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest_helper'
 
 module Sidekiq

--- a/test/test_sidekiq/charts_test.rb
+++ b/test/test_sidekiq/charts_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest_helper'
 
 module Sidekiq

--- a/test/test_sidekiq/configuration_test.rb
+++ b/test/test_sidekiq/configuration_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest_helper'
 
 module Sidekiq

--- a/test/test_sidekiq/history.rb
+++ b/test/test_sidekiq/history.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest_helper'
 
 class TestSidekiq::Statistic < Minitest::Test

--- a/test/test_sidekiq/log_parser_test.rb
+++ b/test/test_sidekiq/log_parser_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest_helper'
 
 module Sidekiq

--- a/test/test_sidekiq/middleware_test.rb
+++ b/test/test_sidekiq/middleware_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest_helper'
 require 'mocha/setup'
 

--- a/test/test_sidekiq/realtime_test.rb
+++ b/test/test_sidekiq/realtime_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest_helper'
 
 module Sidekiq

--- a/test/test_sidekiq/runtime_test.rb
+++ b/test/test_sidekiq/runtime_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest_helper'
 
 module Sidekiq

--- a/test/test_sidekiq/statistic_test.rb
+++ b/test/test_sidekiq/statistic_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest_helper'
 
 module Sidekiq

--- a/test/test_sidekiq/web_api_extension_test.rb
+++ b/test/test_sidekiq/web_api_extension_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # encoding: utf-8
 
 require 'minitest_helper'

--- a/test/test_sidekiq/web_extension_test.rb
+++ b/test/test_sidekiq/web_extension_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # encoding: utf-8
 
 require 'minitest_helper'


### PR DESCRIPTION
Hi ✋ 

1. This PR adds `frozen_string_literal` comment for all ruby files
2. Drops ruby 2.2, adds 2.5 and updates other ruby versions in Travis
3. Fixes run `./bin/console`