### PR TITLE
Resolve deprecation warnings

### DIFF
--- a/lib/sidekiq/statistic/log_parser.rb
+++ b/lib/sidekiq/statistic/log_parser.rb
@@ -11,7 +11,7 @@ module Sidekiq
       end
 
       def parse
-        return [] unless File.exists?(@logfile)
+        return [] unless File.exist?(@logfile)
 
         File
           .readlines(@logfile)


### PR DESCRIPTION
**Before**

```
# Running:

................../code/sidekiq-statistic/lib/sidekiq/statistic/log_parser.rb:14: warning: File.exists? is a deprecated name, use File.exist? instead
............................../code/sidekiq-statistic/lib/sidekiq/statistic/log_parser.rb:14: warning: File.exists? is a deprecated name, use File.exist? instead
............../code/sidekiq-statistic/lib/sidekiq/statistic/log_parser.rb:14: warning: File.exists? is a deprecated name, use File.exist? instead
........................................................................

Finished in 4.722954s, 14.1860 runs/s, 23.7140 assertions/s.
67 runs, 112 assertions, no failures, no errors, no skips
```

**After**

```
# Running:

......................................................................................................................................

Finished in 4.725502s, 14.1784 runs/s, 23.7012 assertions/s.
67 runs, 112 assertions, no failures, no errors, no skips
```