### PR TITLE
Change storing of last_runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## HEAD
+* 03.02.02019: Change storing of last_runtime from date to timestamp (#87) *Kirill Tatchihin*
 * 30.03.2017: Prevent excessive Redis memory usage (#107) *Gareth du Plooy*
 * 08.04.2016: Add new option for displaying last N lines of log file (#91) *Nick Zhebrun*
 * 20.11.2015: Convert value in redis time array to float (#76) *Anton Davydov*

--- a/lib/sidekiq/statistic/middleware.rb
+++ b/lib/sidekiq/statistic/middleware.rb
@@ -17,7 +17,7 @@ module Sidekiq
       ensure
         finish = Time.now
         worker_status[:queue] = msg['queue']
-        worker_status[:last_runtime] = finish.utc
+        worker_status[:last_runtime] = finish.utc.to_i
         worker_status[:time] = (finish - start).to_f.round(3)
         worker_status[:class] = msg['wrapped'] || worker.class.to_s
         if worker_status[:class] == 'ActionMailer::DeliveryJob'
@@ -29,7 +29,7 @@ module Sidekiq
 
       def save_entry_for_worker(worker_status)
         status = worker_status.dup
-        time = worker_status[:last_runtime]
+        time = Time.at(worker_status[:last_runtime]).utc
         realtime_hash = "#{REDIS_HASH}:realtime:#{time.sec}"
         worker_key = "#{time.strftime "%Y-%m-%d"}:#{status.delete :class}"
         timeslist_key = "#{worker_key}:timeslist"

--- a/lib/sidekiq/statistic/views/statistic.erb
+++ b/lib/sidekiq/statistic/views/statistic.erb
@@ -45,7 +45,7 @@
         <% @workers.each do |worker| %>
           <tr>
             <td class="worker"><a href="<%= root_path %>statistic/<%= worker[:name] %>"><%= worker[:name] %></a></td>
-            <td class="worker"><%= formate_date worker[:runtime][:last] %></td>
+            <td class="worker"><%= format_date worker[:runtime][:last] %></td>
             <td class="worker"><%= worker[:queue] %></td>
             <td class="worker"><%= worker[:number_of_calls][:success] %></td>
             <td class="worker"><%= worker[:number_of_calls][:failure] %></td>

--- a/lib/sidekiq/statistic/views/worker.erb
+++ b/lib/sidekiq/statistic/views/worker.erb
@@ -36,8 +36,8 @@
           </thead>
           <% @worker_statistic.each do |worker| %>
             <tr>
-              <td class="worker"><%= formate_date worker[:date], '%e %B %Y' %></td>
-              <td class="worker"><%= formate_date worker[:runtime][:last] %></td>
+              <td class="worker"><%= format_date worker[:date], '%e %B %Y' %></td>
+              <td class="worker"><%= format_date worker[:runtime][:last] %></td>
               <td class="worker"><%= worker[:success] %></td>
               <td class="worker"><%= worker[:failure] %></td>
               <td class="worker"><%= worker[:total] %></td>

--- a/lib/sidekiq/statistic/web_extension_helper.rb
+++ b/lib/sidekiq/statistic/web_extension_helper.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 require 'json'
 
 module Sidekiq
@@ -7,8 +6,8 @@ module Sidekiq
     module WebExtensionHelper
       DAFAULT_DAYS = 20
 
-      def formate_date(string, format = nil)
-        time = string ? Time.parse(string) : Time.now
+      def format_date(date_to_format, format = nil)
+        time = date_to_format ? convert_to_date_object(date_to_format) : Time.now
         time.strftime(format || '%T, %e %B %Y')
       end
 
@@ -22,6 +21,12 @@ module Sidekiq
           [DAFAULT_DAYS]
         end
       end
+
+      private
+
+      def convert_to_date_object(date)
+        date.is_a?(String) ? Time.parse(date) : Time.at(date)
+      end  
     end
   end
 end

--- a/test/test_sidekiq/base_statistic_test.rb
+++ b/test/test_sidekiq/base_statistic_test.rb
@@ -57,7 +57,7 @@ module Sidekiq
 
           Time.stub :now, time do
             values = base_statistic.statistic_for('HistoryWorker')
-            assert_equal [{}, { passed: 1.0, last_job_status: "passed", last_time: time.to_s, queue: "", average_time: 0.0, min_time: 0.0, max_time: 0.0, total_time: 0.0, failed: 0 }], values
+            assert_equal [{}, { passed: 1.0, last_job_status: "passed", last_time: time.to_i, queue: "", average_time: 0.0, min_time: 0.0, max_time: 0.0, total_time: 0.0, failed: 0 }], values
           end
         end
 

--- a/test/test_sidekiq/runtime_test.rb
+++ b/test/test_sidekiq/runtime_test.rb
@@ -16,7 +16,7 @@ module Sidekiq
 
           time = Time.now.utc
           Time.stub :now, time do
-            assert_equal time.to_s, runtime_statistic.last_runtime
+            assert_equal time.to_i, runtime_statistic.last_runtime
           end
         end
 


### PR DESCRIPTION
1. Changed storing of `last_runtime` in redis from `Date` to `timestamp`
2. Fixed typo from `formate_date` to `format_date`

WAS:

```
 {"2019-03-02"=>{"HistoryWorker"=>
{:passed=>1
 :last_job_status=>"passed",
 :last_time=>"2019-03-02 11:36:02 UTC",
...keys}
```
NOW:
```
{"2015-08-11"=>{"HistoryWorker"=>
{:passed=>1,
 :last_job_status=>"failed",
 :last_time=>1439335340,
...keys
}
```

@davydovanton 
https://github.com/davydovanton/sidekiq-statistic/issues/87