### PR TITLE
 Update README.md guide to create standalone Sidekiq server (#103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ require 'sidekiq/web'
 require 'sidekiq-statistic'
 
 use Rack::Session::Cookie, secret: 'some unique secret string here'
-Sidekiq::Web.instance_eval { @middleware.reverse! } # Last added, First Run
 run Sidekiq::Web
 ```
 


### PR DESCRIPTION
1. Updated README.md guide to create standalone sidekiq server. In newer versions of sidekiq, there is no `middleware` instance variable for `Sidekiq::Web`

https://github.com/davydovanton/sidekiq-statistic/issues/103