### PR TITLE
(#123) Change log parser regexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## HEAD
+* 08.03.2019: Change LogParser regexp (#81) *Kirill Tatchihin*
 * 03.02.02019: Change storing of last_runtime from date to timestamp (#87) *Kirill Tatchihin*
 * 30.03.2017: Prevent excessive Redis memory usage (#107) *Gareth du Plooy*
 * 08.04.2016: Add new option for displaying last N lines of log file (#91) *Nick Zhebrun*

--- a/lib/sidekiq/statistic/log_parser.rb
+++ b/lib/sidekiq/statistic/log_parser.rb
@@ -16,7 +16,7 @@ module Sidekiq
         File
           .readlines(@logfile)
           .last(last_log_lines)
-          .map{ |line| sub_line(line) if line[/\W?#@worker_name\W?/] }
+          .map{ |line| sub_line(line) unless line.match(log_line_contains_worker_regexp).nil? }
           .compact
       end
 
@@ -56,6 +56,10 @@ module Sidekiq
 
       def last_log_lines
         Sidekiq::Statistic.configuration.last_log_lines
+      end
+
+      def log_line_contains_worker_regexp
+        /([\W]+|^)#{@worker_name}([\W]+|$)/
       end
     end
   end

--- a/test/helpers/logfile.log
+++ b/test/helpers/logfile.log
@@ -1,3 +1,4 @@
 HistoryWorker (done) JID-36a2b8bd6a370834f979f5ee
 HistoryWorker (start)
+AnotherHistoryWorker (fail) JID-79d0a83b5eb21f7d0ae49f99
 HistoryWorker (fail) JID-219f4e9b9013bfec76faa270

--- a/test/test_sidekiq/log_parser_test.rb
+++ b/test/test_sidekiq/log_parser_test.rb
@@ -35,9 +35,10 @@ module Sidekiq
 
           describe 'when called with param AnotherHistoryWorker' do
             let(:log_parser) { Sidekiq::Statistic::LogParser.new('AnotherHistoryWorker') }
-          
+
             it 'returns lines only with AnotherHistoryWorker inside' do
               result = ["AnotherHistoryWorker (fail) <span class=\"statistic__jid js-jid__79d0a83b5eb21f7d0ae49f99\"data-target=\".js-jid__79d0a83b5eb21f7d0ae49f99\" style=\"background-color: rgba(192,160,192,0.2);\">JID-79d0a83b5eb21f7d0ae49f99</span>"]
+
               assert_equal result, log_parser.parse
             end
           end

--- a/test/test_sidekiq/log_parser_test.rb
+++ b/test/test_sidekiq/log_parser_test.rb
@@ -32,6 +32,15 @@ module Sidekiq
               assert_equal  result, log_parser.parse
             end
           end
+
+          describe 'when called with param AnotherHistoryWorker' do
+            let(:log_parser) { Sidekiq::Statistic::LogParser.new('AnotherHistoryWorker') }
+          
+            it 'returns lines only with AnotherHistoryWorker inside' do
+              result = ["AnotherHistoryWorker (fail) <span class=\"statistic__jid js-jid__79d0a83b5eb21f7d0ae49f99\"data-target=\".js-jid__79d0a83b5eb21f7d0ae49f99\" style=\"background-color: rgba(192,160,192,0.2);\">JID-79d0a83b5eb21f7d0ae49f99</span>"]
+              assert_equal result, log_parser.parse
+            end
+          end
         end
 
         describe 'when worker don\'t called' do


### PR DESCRIPTION
1. Changed condition to check if log line contains info about worker.
Was:
Parser was  just checking for substring in log line
Now:
LogParser is now checking for info about worker with updated regex using the `match` method

https://github.com/davydovanton/sidekiq-statistic/issues/123