### PR TITLE
fix update busy workers

### DIFF
--- a/lib/sidekiq/statistic/views/statistic.erb
+++ b/lib/sidekiq/statistic/views/statistic.erb
@@ -42,7 +42,7 @@
           <th><%= t('MaxTimeSec') %></th>
           <th><%= t('LastJobStatus') %></th>
         </thead>
-        <% @workers.each do |worker| %>
+        <% @all_workers.each do |worker| %>
           <tr>
             <td class="worker"><a href="<%= root_path %>statistic/<%= worker[:name] %>"><%= worker[:name] %></a></td>
             <td class="worker"><%= format_date worker[:runtime][:last] %></td>

--- a/lib/sidekiq/statistic/web_extension.rb
+++ b/lib/sidekiq/statistic/web_extension.rb
@@ -28,7 +28,7 @@ module Sidekiq
 
         app.get '/statistic' do
           statistic = Sidekiq::Statistic::Workers.new(*calculate_date_range(params))
-          @workers = statistic.display
+          @all_workers = statistic.display
           render(:erb, File.read(File.join(view_path, 'statistic.erb')))
         end
 


### PR DESCRIPTION
The number of busy workers was not being updated in the navbar 
![sidekiq-bar](https://user-images.githubusercontent.com/15057257/60348943-efdea200-9996-11e9-84ab-c4698a0023e1.png)

the array name `workers` was conflicting with`workers` inside sidekiq gem `sidekiq/web/views/_summary.erb`