### PR TITLE
Translate pt-br date format

### DIFF
--- a/lib/sidekiq/statistic/locales/pt-br.yml
+++ b/lib/sidekiq/statistic/locales/pt-br.yml
@@ -31,4 +31,3 @@ pt-br: # <---- change this to your locale code
     formats:
       default: "%d/%m/%Y"
       datetime: "%d/%m/%Y - %T"
-

--- a/lib/sidekiq/statistic/locales/pt-br.yml
+++ b/lib/sidekiq/statistic/locales/pt-br.yml
@@ -27,3 +27,8 @@ pt-br: # <---- change this to your locale code
   LastRun: Última execução
   EmptyLogs: Nenhum resultado
   SearchLogs: Pesquisar no arquivo de logs
+  date:
+    formats:
+      withoutTime: "%d/%m/%Y"
+      withTime: "%d/%m/%Y - %T"
+

--- a/lib/sidekiq/statistic/locales/pt-br.yml
+++ b/lib/sidekiq/statistic/locales/pt-br.yml
@@ -29,6 +29,6 @@ pt-br: # <---- change this to your locale code
   SearchLogs: Pesquisar no arquivo de logs
   date:
     formats:
-      withoutTime: "%d/%m/%Y"
-      withTime: "%d/%m/%Y - %T"
+      default: "%d/%m/%Y"
+      datetime: "%d/%m/%Y - %T"
 

--- a/lib/sidekiq/statistic/views/statistic.erb
+++ b/lib/sidekiq/statistic/views/statistic.erb
@@ -46,7 +46,7 @@
             <td class="worker">
               <a href="<%= root_path %>statistic/<%= worker[:name] %>"><%= worker[:name] %></a>
             </td>
-            <td class="worker"><%= format_date worker[:runtime][:last], 'withTime' %></td>
+            <td class="worker"><%= format_date worker[:runtime][:last], 'datetime' %></td>
             <td class="worker"><%= worker[:queue] %></td>
             <td class="worker"><%= worker[:number_of_calls][:success] %></td>
             <td class="worker"><%= worker[:number_of_calls][:failure] %></td>

--- a/lib/sidekiq/statistic/views/statistic.erb
+++ b/lib/sidekiq/statistic/views/statistic.erb
@@ -46,7 +46,7 @@
             <td class="worker">
               <a href="<%= root_path %>statistic/<%= worker[:name] %>"><%= worker[:name] %></a>
             </td>
-            <td class="worker"><%= format_date worker[:runtime][:last] %></td>
+            <td class="worker"><%= format_date worker[:runtime][:last], 'withTime' %></td>
             <td class="worker"><%= worker[:queue] %></td>
             <td class="worker"><%= worker[:number_of_calls][:success] %></td>
             <td class="worker"><%= worker[:number_of_calls][:failure] %></td>

--- a/lib/sidekiq/statistic/views/worker.erb
+++ b/lib/sidekiq/statistic/views/worker.erb
@@ -36,8 +36,8 @@
           </thead>
           <% @worker_statistic.each do |worker| %>
             <tr>
-              <td class="worker"><%= format_date worker[:date], 'withoutTime' %></td>
-              <td class="worker"><%= format_date worker[:runtime][:last], 'withTime' %></td>
+              <td class="worker"><%= format_date worker[:date] %></td>
+              <td class="worker"><%= format_date worker[:runtime][:last], 'datetime' %></td>
               <td class="worker"><%= worker[:success] %></td>
               <td class="worker"><%= worker[:failure] %></td>
               <td class="worker"><%= worker[:total] %></td>

--- a/lib/sidekiq/statistic/views/worker.erb
+++ b/lib/sidekiq/statistic/views/worker.erb
@@ -36,8 +36,8 @@
           </thead>
           <% @worker_statistic.each do |worker| %>
             <tr>
-              <td class="worker"><%= format_date worker[:date], '%e %B %Y' %></td>
-              <td class="worker"><%= format_date worker[:runtime][:last] %></td>
+              <td class="worker"><%= format_date worker[:date], 'withoutTime' %></td>
+              <td class="worker"><%= format_date worker[:runtime][:last], 'withTime' %></td>
               <td class="worker"><%= worker[:success] %></td>
               <td class="worker"><%= worker[:failure] %></td>
               <td class="worker"><%= worker[:total] %></td>

--- a/lib/sidekiq/statistic/web_extension_helper.rb
+++ b/lib/sidekiq/statistic/web_extension_helper.rb
@@ -25,7 +25,7 @@ module Sidekiq
       private
 
       def date_format(format)
-        get_locale.dig('date', 'formats', format) || '%m/%e/%Y - %T'
+        get_locale.dig('date', 'formats', format || 'default') || '%m/%d/%Y'
       end
 
       def convert_to_date_object(date)

--- a/lib/sidekiq/statistic/web_extension_helper.rb
+++ b/lib/sidekiq/statistic/web_extension_helper.rb
@@ -8,7 +8,7 @@ module Sidekiq
 
       def format_date(date_to_format, format = nil)
         time = date_to_format ? convert_to_date_object(date_to_format) : Time.now
-        time.strftime(format || '%T, %e %B %Y')
+        time.strftime(date_format(format))
       end
 
       def calculate_date_range(params)
@@ -24,9 +24,13 @@ module Sidekiq
 
       private
 
+      def date_format(format)
+        get_locale.dig('date', 'formats', format) || '%m/%e/%Y - %T'
+      end
+
       def convert_to_date_object(date)
         date.is_a?(String) ? Time.parse(date) : Time.at(date)
-      end  
+      end
     end
   end
 end

--- a/test/test_sidekiq/web_extension_helper_test.rb
+++ b/test/test_sidekiq/web_extension_helper_test.rb
@@ -16,19 +16,17 @@ module Sidekiq
     describe '.format_date' do
       let(:header) { { 'HTTP_ACCEPT_LANGUAGE' => 'pt-br' } }
       let(:datetime) { Time.now }
+      let(:helper) { Helper.new(header, {}) }
 
       describe "when doesn't have translation" do
+        before { header['HTTP_ACCEPT_LANGUAGE'] = 'xx-xx' }
+
         it 'return date with en format' do
-          header['HTTP_ACCEPT_LANGUAGE'] = 'xx-xx'
-
-          helper = Helper.new(header, {})
-
           assert_equal helper.format_date(datetime), datetime.strftime('%m/%d/%Y')
         end
       end
 
       describe 'when have translation' do
-        let(:helper) { Helper.new(header, {}) }
         it 'return date with default format' do
           default_format = helper.get_locale.dig('date', 'formats', 'default')
           assert_equal helper.format_date(datetime), datetime.strftime(default_format)

--- a/test/test_sidekiq/web_extension_helper_test.rb
+++ b/test/test_sidekiq/web_extension_helper_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# encoding: utf-8
+
+require 'minitest_helper'
+require 'json'
+
+module Sidekiq
+  class Helper < Sidekiq::WebAction
+    include Sidekiq::Statistic::WebExtensionHelper
+  end
+
+  describe 'WebExtensionHelper' do
+    include Rack::Test::Methods
+
+    describe '.format_date' do
+      let(:header) { { 'HTTP_ACCEPT_LANGUAGE' => 'pt-br' } }
+      let(:datetime) { Time.now }
+
+      describe "when doesn't have translation" do
+        it 'return date with en format' do
+          header['HTTP_ACCEPT_LANGUAGE'] = 'xx-xx'
+
+          helper = Helper.new(header, {})
+
+          assert_equal helper.format_date(datetime), datetime.strftime('%m/%d/%Y')
+        end
+      end
+
+      describe 'when have translation' do
+        let(:helper) { Helper.new(header, {}) }
+        it 'return date with default format' do
+          default_format = helper.get_locale.dig('date', 'formats', 'default')
+          assert_equal helper.format_date(datetime), datetime.strftime(default_format)
+        end
+
+        it 'return date with datetime format' do
+          datetime_format = helper.get_locale.dig('date', 'formats', 'datetime')
+          assert_equal helper.format_date(datetime, 'datetime'), datetime.strftime(datetime_format)
+        end
+      end
+    end
+  end
+end

--- a/test/test_sidekiq/web_extension_helper_test.rb
+++ b/test/test_sidekiq/web_extension_helper_test.rb
@@ -3,7 +3,6 @@
 # encoding: utf-8
 
 require 'minitest_helper'
-require 'json'
 
 module Sidekiq
   class Helper < Sidekiq::WebAction


### PR DESCRIPTION
Related do #132 
To prevent a big translate file with months names, i adopted the following format:
```day/month/year``` ```pt-br.yml``` and ```month/day/year``` as default to prevent errors when the translation is missing.

