### PR TITLE
Fix deprecation warnings related to Minitest 6

### DIFF
--- a/test/test_sidekiq/helpers/date_test.rb
+++ b/test/test_sidekiq/helpers/date_test.rb
@@ -52,11 +52,11 @@ module Sidekiq
         params = { 'dateFrom' => two_days_ago.to_s,
                    'dateTo' => today.to_s }
 
-        helper_date.calculate_date_range(params).must_equal([diference, today])
+        _(helper_date.calculate_date_range(params)).must_equal([diference, today])
       end
 
       it 'returns default range' do
-        helper_date.calculate_date_range({}).must_equal([20])
+        _(helper_date.calculate_date_range({})).must_equal([20])
       end
     end
   end

--- a/test/test_sidekiq/statistic_test.rb
+++ b/test/test_sidekiq/statistic_test.rb
@@ -96,7 +96,7 @@ module Sidekiq
 
           subject = statistic.display
 
-          subject.must_be_instance_of Array
+          _(subject).must_be_instance_of Array
           assert_equal subject[0].keys.sort,
                        %i[name last_job_status number_of_calls queue runtime].sort
 
@@ -110,7 +110,7 @@ module Sidekiq
 
           subject = statistic.display_per_day(worker)
 
-          subject.must_be_instance_of Array
+          _(subject).must_be_instance_of Array
           assert_equal subject[0].keys.sort,
                        %i[date failure last_job_status runtime success total].sort
           assert_equal Time.now.strftime("%Y-%m-%d"), subject[0][:date]
@@ -124,7 +124,7 @@ module Sidekiq
           worker_statistic = base_statistic.statistic_for(worker)[1]
           subject = statistic.runtime_for_day(worker, worker_statistic)
 
-          subject.must_be_instance_of Hash
+          _(subject).must_be_instance_of Hash
           assert_equal subject.keys.sort, %i[average last max min total].sort
           assert_equal worker_statistic[:average_time], subject[:average]
           assert_equal worker_statistic[:last_time], subject[:last]

--- a/test/test_sidekiq/web_api_extension_test.rb
+++ b/test/test_sidekiq/web_api_extension_test.rb
@@ -20,7 +20,7 @@ module Sidekiq
           get '/api/statistic.json'
 
           response = Sidekiq.load_json(last_response.body)
-          response['workers'].must_equal []
+          _(response['workers']).must_equal []
         end
       end
 
@@ -30,8 +30,8 @@ module Sidekiq
           get '/api/statistic.json'
 
           response = Sidekiq.load_json(last_response.body)
-          response['workers'].wont_equal []
-          response['workers'].first.keys.must_equal %w[name last_job_status number_of_calls queue runtime]
+          _(response['workers']).wont_equal []
+          _( response['workers'].first.keys).must_equal %w[name last_job_status number_of_calls queue runtime]
         end
       end
 
@@ -45,7 +45,7 @@ module Sidekiq
             get '/api/statistic.json?dateFrom=2015-07-28&dateTo=2015-07-29'
 
             response = Sidekiq.load_json(last_response.body)
-            response['workers'].must_equal []
+            _(response['workers']).must_equal []
           end
         end
 
@@ -54,8 +54,8 @@ module Sidekiq
             get "/api/statistic.json?dateFrom=2015-07-28&dateTo=#{Date.today}"
 
             response = Sidekiq.load_json(last_response.body)
-            response['workers'].wont_equal []
-            response['workers'].count.must_equal 1
+            _(response['workers']).wont_equal []
+            _(response['workers'].count).must_equal 1
           end
         end
       end
@@ -67,7 +67,7 @@ module Sidekiq
           get '/api/statistic/HistoryWorker.json'
 
           response = Sidekiq.load_json(last_response.body)
-          response['days'].must_equal []
+          _(response['days']).must_equal []
         end
       end
 
@@ -77,8 +77,8 @@ module Sidekiq
           get '/api/statistic/HistoryWorker.json'
 
           response = Sidekiq.load_json(last_response.body)
-          response['days'].wont_equal []
-          response['days'].first.keys.must_equal %w[date failure success total last_job_status runtime]
+          _(response['days']).wont_equal []
+          _(response['days'].first.keys).must_equal %w[date failure success total last_job_status runtime]
         end
       end
 
@@ -92,7 +92,7 @@ module Sidekiq
             get '/api/statistic/HistoryWorker.json?dateFrom=2015-07-28&dateTo=2015-07-29'
 
             response = Sidekiq.load_json(last_response.body)
-            response['days'].must_equal []
+            _(response['days']).must_equal []
           end
         end
 
@@ -101,8 +101,8 @@ module Sidekiq
             get "/api/statistic/HistoryWorker.json?dateFrom=2015-07-28&dateTo=#{Date.today}"
 
             response = Sidekiq.load_json(last_response.body)
-            response['days'].wont_equal []
-            response['days'].count.must_equal 1
+            _(response['days']).wont_equal []
+            _(response['days'].count).must_equal 1
           end
         end
       end

--- a/test/test_sidekiq/web_extension_test.rb
+++ b/test/test_sidekiq/web_extension_test.rb
@@ -28,9 +28,9 @@ module Sidekiq
       end
 
       it 'can display home with statistic tab' do
-        last_response.status.must_equal 200
-        last_response.body.must_match(/Sidekiq/)
-        last_response.body.must_match(/Statistic/)
+        _(last_response.status).must_equal 200
+        _(last_response.body).must_match(/Sidekiq/)
+        _(last_response.body).must_match(/Statistic/)
       end
     end
 
@@ -40,24 +40,24 @@ module Sidekiq
       end
 
       it 'can display statistic page without any failures' do
-        last_response.status.must_equal 200
-        last_response.body.must_match(/statistic/)
+        _(last_response.status).must_equal 200
+        _(last_response.body).must_match(/statistic/)
       end
 
       describe 'when there are statistic' do
         it 'should be successful' do
-          last_response.status.must_equal 200
+          _(last_response.status).must_equal 200
         end
       end
 
       it 'can display worker table' do
-        last_response.body.must_match(/Worker/)
-        last_response.body.must_match(/Date/)
-        last_response.body.must_match(/Success/)
-        last_response.body.must_match(/Failure/)
-        last_response.body.must_match(/Total/)
-        last_response.body.must_match(/Time\(sec\)/)
-        last_response.body.must_match(/Average\(sec\)/)
+        _(last_response.body).must_match(/Worker/)
+        _(last_response.body).must_match(/Date/)
+        _(last_response.body).must_match(/Success/)
+        _(last_response.body).must_match(/Failure/)
+        _(last_response.body).must_match(/Total/)
+        _(last_response.body).must_match(/Time\(sec\)/)
+        _(last_response.body).must_match(/Average\(sec\)/)
       end
     end
 
@@ -67,7 +67,7 @@ module Sidekiq
       end
 
       it 'can display statistic page without any failures' do
-        last_response.status.must_equal 200
+        _(last_response.status).must_equal 200
         response = JSON.parse(last_response.body)
 
         assert_includes response, 'date'
@@ -79,7 +79,7 @@ module Sidekiq
 
       describe 'when there are statistic' do
         it 'should be successful' do
-          last_response.status.must_equal 200
+          _(last_response.status).must_equal 200
         end
       end
     end


### PR DESCRIPTION
Minitest 6 will deprecate global expectations, so the most recent versions are already warning us about these.

This PR changes the existing expectations on the project to local (_() syntax).