### PR TITLE
Refactoring colors helper to avoid light colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## HEAD
 
-* Fix UI problem when the number of workers increases too much (#140) *Guilherme Quirino*
+* 06.12.2019: Avoid whites when generating colors (#141) *Wender Freese*
+* 25.11.2019: Add line break in log visualization *Dmitriy*
+* 25.11.2019: Fix high memory usage in Log Parser *Dmitriy*
+* 04.10.2019: Fix UI problem when the number of workers increases too much (#140) *Guilherme Quirino*
 
 ## 1.4.0
 

--- a/lib/sidekiq/statistic/helpers/color.rb
+++ b/lib/sidekiq/statistic/helpers/color.rb
@@ -4,22 +4,38 @@ module Sidekiq
   module Statistic
     module Helpers
       module Color
-        def for(worker_name, format = :rgb)
-          rgb = Digest::MD5.hexdigest(worker_name)[0..5]
-                           .scan(/../)
-                           .map { |color| color.to_i(16) }
-                           .join(',')
+        class << self
+          BASE = 16
+          LIMIT_NUMBERT_TO_AVOID_WHITES = 215
 
-          return to_hex(rgb) if format == :hex
+          def for(phrase, format: :rgb)
+            return hex(phrase) if format == :hex
 
-          rgb
+            rgb(phrase)
+          end
+
+          private
+
+          def rgb(phrase)
+            digested_unique_color(phrase).join(',')
+          end
+
+          def hex(phrase)
+            '#' + digested_unique_color(phrase).map do |number|
+              number.to_s(BASE).rjust(2, '0')
+            end.join
+          end
+
+          def digested_unique_color(phrase)
+            Digest::MD5.hexdigest(phrase)[0..5]
+                       .scan(/../)
+                       .map(&method(:hex_pair_to_number))
+          end
+
+          def hex_pair_to_number(pair)
+            pair.to_i(BASE) % LIMIT_NUMBERT_TO_AVOID_WHITES
+          end
         end
-
-        def to_hex(rgb)
-          '#' + rgb.split(',').map { |v| v.to_i.to_s(16).rjust(2, '0').upcase }.join
-        end
-
-        module_function :for, :to_hex
       end
     end
   end

--- a/lib/sidekiq/statistic/helpers/color.rb
+++ b/lib/sidekiq/statistic/helpers/color.rb
@@ -6,7 +6,7 @@ module Sidekiq
       module Color
         class << self
           BASE = 16
-          LIMIT_NUMBERT_TO_AVOID_WHITES = 215
+          LIMIT_NUMBER_TO_AVOID_WHITES = 215
 
           def for(phrase, format: :rgb)
             return hex(phrase) if format == :hex
@@ -33,7 +33,7 @@ module Sidekiq
           end
 
           def hex_pair_to_number(pair)
-            pair.to_i(BASE) % LIMIT_NUMBERT_TO_AVOID_WHITES
+            pair.to_i(BASE) % LIMIT_NUMBER_TO_AVOID_WHITES
           end
         end
       end

--- a/lib/sidekiq/statistic/statistic/charts.rb
+++ b/lib/sidekiq/statistic/statistic/charts.rb
@@ -5,17 +5,25 @@ module Sidekiq
     class Charts < Base
       def information_for(type)
         worker_names.reverse.map.with_index do |worker, i|
-          color_hex = Helpers::Color.for(worker, :hex)
           index = "data#{i}"
           dataset = [index] + statistic_for(worker).map { |val| val.fetch(type, 0) }
-          { worker: worker,
+
+          {
+            worker: worker,
             dataset: dataset,
-            color: color_hex }
+            color: color(worker)
+          }
         end
       end
 
       def dates
         @dates ||= statistic_hash.flat_map(&:keys)
+      end
+
+      private
+
+      def color(phrase)
+        Helpers::Color.for(phrase, format: :hex)
       end
     end
   end

--- a/test/test_sidekiq/helpers/color_test.rb
+++ b/test/test_sidekiq/helpers/color_test.rb
@@ -8,14 +8,12 @@ module Sidekiq
       describe Color do
         include Rack::Test::Methods
 
-        let(:worker_name) { 'HistoryWorker' }
-        let(:rgb_color) { '102,63,243' }
-        let(:hex_color) { '#663FF3' }
+        let(:phrase) { 'HistoryWorker' }
 
         describe 'when passes rgb format' do
           describe '.for' do
             it 'returns rgb format' do
-              assert_equal rgb_color, Color.for(worker_name, :rgb)
+              assert_equal '102,63,28', Color.for(phrase, format: :rgb)
             end
           end
         end
@@ -23,7 +21,7 @@ module Sidekiq
         describe 'when passes hex format' do
           describe '.for' do
             it 'return hex format' do
-              assert_equal hex_color, Color.for(worker_name, :hex)
+              assert_equal '#663f1c', Color.for(phrase, format: :hex)
             end
           end
         end


### PR DESCRIPTION
Related to: https://github.com/davydovanton/sidekiq-statistic/issues/141

#### Changes included

- Removes `upcase` in `hex` colors, we don't exactly need to up case letters
- To avoid whites on generated colors I've tried some approaches
  - Use base 15 instead of 16 and avoid the `F` letter
    - Pros:
      - Simple solution
      - Would not require too much complexity
    - Cons:
      - It doesn't solve the same problem for RGB cases
      - Excluding `F` letter would lead the hex color to have fewer characters and considering we need to justify the values to build pairs we could end up with the repeated black colors
  - Normalize RGB values an use it to generate the HEX one, the logic I used to normalize RGB is basically decreasing the number if it is greater than `215`
    - Once the white equivalent in RGB is `255, 255, 255` if we decrease those numbers we're gonna have a darker color

#### Examples

##### > 215

`250 % 215 = 235`
`220 % 215 = 5`

##### < 215

`190 % 215 = 190`
`20 % 215 = 20`