### PR TITLE
Change workers toggle visibility button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+* 01.07.2020: Update workers toggle visibility button on RealTime (#156) *kostadriano*
 * 06.12.2019: Avoid whites when generating colors (#141) *Wender Freese*
 * 25.11.2019: Add line break in log visualization *Dmitriy*
 * 25.11.2019: Fix high memory usage in Log Parser *Dmitriy*

--- a/lib/sidekiq/statistic/locales/de.yml
+++ b/lib/sidekiq/statistic/locales/de.yml
@@ -1,7 +1,7 @@
 # elements like %{queue} are variables and should not be translated
 de: # <---- change this to your locale code
   Queue: Queue
-  Exclude: Ausblenden
+  Show/Hide: Anzeigen / Ausblenden
   Index: Übersicht
   RealtimeStatistic: Echtzeitstatistik
   Statistic: Statistik

--- a/lib/sidekiq/statistic/locales/en.yml
+++ b/lib/sidekiq/statistic/locales/en.yml
@@ -1,7 +1,7 @@
 # elements like %{queue} are variables and should not be translated
 en: # <---- change this to your locale code
   Queue: Queue
-  Exclude: Exclude
+  Show/Hide: Show / Hide
   Index: Index
   RealtimeStatistic: Realtime Statistic
   Statistic: Statistic

--- a/lib/sidekiq/statistic/locales/fr.yml
+++ b/lib/sidekiq/statistic/locales/fr.yml
@@ -1,7 +1,7 @@
 # elements like %{queue} are variables and should not be translated
 fr: # <---- change this to your locale code
   Queue: Queue
-  Exclude: Exclure
+  Show/Hide: Afficher / Masquer
   Index: Indice
   RealtimeStatistic: Statistique en temps réel
   Statistic: Statistique

--- a/lib/sidekiq/statistic/locales/it.yml
+++ b/lib/sidekiq/statistic/locales/it.yml
@@ -1,7 +1,7 @@
 # elements like %{queue} are variables and should not be translated
 it: # <---- change this to your locale code
   Queue: Fila
-  Exclude: Escludi
+  Show/Hide: Mostrare / Nascondere
   Index: Indice
   RealtimeStatistic: Statistiche in Tempo Reale
   Statistic: Statistiche

--- a/lib/sidekiq/statistic/locales/jp.yml
+++ b/lib/sidekiq/statistic/locales/jp.yml
@@ -1,7 +1,7 @@
 # elements like %{queue} are variables and should not be translated
 jp: # <---- change this to your locale code
   Queue: キュー
-  Exclude: 削除
+  Show/Hide: 表示/非表示
   Index: 索引
   RealtimeStatistic: リアルタイム統計
   Statistic: 統計

--- a/lib/sidekiq/statistic/locales/pl.yml
+++ b/lib/sidekiq/statistic/locales/pl.yml
@@ -1,7 +1,7 @@
 # elements like %{queue} are variables and should not be translated
 pl: # <---- change this to your locale code
   Queue: Kolejka
-  Exclude: Wykluczyć
+  Show/Hide: Pokazać / Ukryć
   Index: Indeks
   RealtimeStatistic: Statystyka w czasie rzeczywistym
   Statistic: Statystyka

--- a/lib/sidekiq/statistic/locales/pt-br.yml
+++ b/lib/sidekiq/statistic/locales/pt-br.yml
@@ -1,7 +1,7 @@
 # elements like %{queue} are variables and should not be translated
 pt-br: # <---- change this to your locale code
   Queue: Fila
-  Exclude: Excluir
+  Show/Hide: Mostrar / Esconder
   Index: Índice
   RealtimeStatistic: Estatística em tempo real
   Statistic: Estatística

--- a/lib/sidekiq/statistic/locales/ru.yml
+++ b/lib/sidekiq/statistic/locales/ru.yml
@@ -1,7 +1,7 @@
 # elements like %{queue} are variables and should not be translated
 ru: # <---- change this to your locale code
   Queue: Очередь
-  Exclude: Исключить
+  Show/Hide: шоу / скрывать
   Index: Главная
   RealtimeStatistic: Статистика в реальном времени
   Statistic: Статистика

--- a/lib/sidekiq/statistic/locales/uk.yml
+++ b/lib/sidekiq/statistic/locales/uk.yml
@@ -1,7 +1,7 @@
 # elements like %{queue} are variables and should not be translated
 uk: # <---- change this to your locale code
   Queue: Черга
-  Exclude: Вилучити
+  Show/Hide: шоу / ховатися
   Index: Головна
   RealtimeStatistic: Статистика у реальному часі
   Statistic: Статистика

--- a/lib/sidekiq/statistic/views/realtime.erb
+++ b/lib/sidekiq/statistic/views/realtime.erb
@@ -32,8 +32,8 @@
     <table class="workers__table table table-hover table-bordered table-striped table-white">
       <thead>
         <tr>
-          <th><%= t('Exclude') %></th>
           <th><%= t('Worker') %></th>
+          <th><%= t('Show/Hide') %></th>
         </tr>
       </thead>
       <% @workers.each do |worker| %>

--- a/lib/sidekiq/statistic/views/realtime.erb
+++ b/lib/sidekiq/statistic/views/realtime.erb
@@ -1,5 +1,6 @@
 <% add_to_head do %>
   <link href="<%= root_path %>sidekiq-statistic.css" media="screen" rel="stylesheet" type="text/css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 <% end %>
 
 <script type="text/javascript" src="<%= root_path %>c3.js"></script>
@@ -37,10 +38,12 @@
       </thead>
       <% @workers.each do |worker| %>
         <tr>
-          <td class="worker">
-            <input class="worker__checkbox" type="checkbox" name="<%= worker %>" value="<%= worker %>">
-          </td>
           <td class="worker"><a href="<%= root_path %>statistic/<%= worker %>"><%= worker %></a></td>
+          <td class="worker">
+            <button class="worker__toggle-visibility btn" name="<%= worker %>" data-visible=true>
+              <i class="worker__visibility-icon fa fa-eye"></i>
+            </button>
+          </td>
         </tr>
       <% end %>
     </table>

--- a/lib/sidekiq/statistic/views/realtime_statistic.js
+++ b/lib/sidekiq/statistic/views/realtime_statistic.js
@@ -30,8 +30,16 @@ $(function () {
   var interval
   var excludedWorkers = []
 
+  var toggleVisibilityButton = '.worker__toggle-visibility'
+
+  function noVisibleWorkers() {
+    return $(toggleVisibilityButton)
+      .get()
+      .every(element => $(element).data('visible') === false)
+  }
+
   function updateChart() {
-    if ($('.worker__checkbox').length === $('.worker__checkbox:checked').length) {
+    if (noVisibleWorkers()) {
       return
     }
 
@@ -62,11 +70,23 @@ $(function () {
       stopRealtimeChart()
       stopButton.hide()
       startButton.show()
-    } 
+    }
   });
 
-  $('.worker__checkbox').change(function() {
+  var visibilityStatusClass = {
+    true: 'fa-eye',
+    false: 'fa-eye-slash',
+  }
+
+  $(toggleVisibilityButton).click(function() {
     var name = this.name
+    var visibilityIcon = $(this).find('.worker__visibility-icon')
+    var currentStatus = $(this).data('visible')
+    var newStatus = !currentStatus
+
+    visibilityIcon.toggleClass(`${visibilityStatusClass[currentStatus]} ${visibilityStatusClass[newStatus]}`)
+
+    $(this).data('visible', newStatus)
 
     failedChart.toggle(name)
     passedChart.toggle(name)

--- a/lib/sidekiq/statistic/views/sidekiq-statistic.css
+++ b/lib/sidekiq/statistic/views/sidekiq-statistic.css
@@ -61,6 +61,27 @@
 
 .workers__table tbody tr td {
   text-align: center;
+  vertical-align: middle;
+}
+
+.worker__toggle-visibility {
+  border-radius: 50%;
+  box-shadow: none;
+  background: inherit;
+  padding: 8px 12px;
+}
+
+.worker__toggle-visibility:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.worker__toggle-visibility:active {
+  background: rgba(0, 0, 0, 0.1);
+}
+
+.worker__toggle-visibility:focus, .worker__toggle-visibility:active {
+  outline: none !important;
+  box-shadow: none;
 }
 
 #chartjs-tooltip {


### PR DESCRIPTION
This PR is a feature to #154. 

It changes the old toggle worker visibility checkbox to a button with an icon.

![showhideworkers1](https://user-images.githubusercontent.com/15300776/86144534-2f6d2c00-bacc-11ea-978a-5101f4330ba0.gif)
