### PR TITLE
Add excluded workers on real-time request

### DIFF
--- a/lib/sidekiq/statistic/views/realtime_statistic.js
+++ b/lib/sidekiq/statistic/views/realtime_statistic.js
@@ -82,16 +82,16 @@ $(function () {
     var name = this.name
     var visibilityIcon = $(this).find('.worker__visibility-icon')
     var currentStatus = $(this).data('visible')
-    var newStatus = !currentStatus
+    var visible = !currentStatus
 
-    visibilityIcon.toggleClass(`${visibilityStatusClass[currentStatus]} ${visibilityStatusClass[newStatus]}`)
+    visibilityIcon.toggleClass(`${visibilityStatusClass[currentStatus]} ${visibilityStatusClass[visible]}`)
 
-    $(this).data('visible', newStatus)
+    $(this).data('visible', visible)
 
     failedChart.toggle(name)
     passedChart.toggle(name)
 
-    if(this.checked) {
+    if(!visible) {
       excludedWorkers.push(this.name)
     } else {
       excludedWorkers.splice($.inArray(this.name, excludedWorkers), 1)


### PR DESCRIPTION
> This PR  fix a problem from #156

Testing I noticed that the workers was being excluded from the chart, BUT not from the server response. Then I realized that it was a mistake in JS code made by me in the last PR that was not adding the hide worker on the list.

@wenderjean I really sorry about that, it was my mistake on the last PR, didn't notice that back there. Now it's working fine :).

### Before: 
![image](https://user-images.githubusercontent.com/15300776/87251345-5bc86700-c441-11ea-91ff-9d4d89bdbd42.png)

----

### After

![image](https://user-images.githubusercontent.com/15300776/87251373-9f22d580-c441-11ea-9447-3d2d136de63f.png)


