### PR TITLE
Fix: change workers table visited links color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,76 +1,72 @@
 ## HEAD
-
-- 02.09.2020: Improve dark mode workers table links readability(#160) _V-Gutierrez_
-- 25.08.2020: Refactor realtime statistic JS code (#159) _kostadriano_
-- 24.08.2020: Fix translation pt-Br start/stop (#153) _brunnohenrique_
-- 01.07.2020: Update workers toggle visibility button on RealTime (#156) _kostadriano_
-- 06.12.2019: Avoid whites when generating colors (#141) _Wender Freese_
-- 25.11.2019: Add line break in log visualization _Dmitriy_
-- 25.11.2019: Fix high memory usage in Log Parser _Dmitriy_
-- 04.10.2019: Fix UI problem when the number of workers increases too much (#140) _Guilherme Quirino_
+* 02.09.2020: Improve dark mode workers table links readability(#160) *V-Gutierrez*
+* 25.08.2020: Refactor realtime statistic JS code (#159) *kostadriano*
+* 24.08.2020: Fix translation pt-Br start/stop (#153) *brunnohenrique*
+* 01.07.2020: Update workers toggle visibility button on RealTime (#156) *kostadriano*
+* 06.12.2019: Avoid whites when generating colors (#141) *Wender Freese*
+* 25.11.2019: Add line break in log visualization *Dmitriy*
+* 25.11.2019: Fix high memory usage in Log Parser *Dmitriy*
+* 04.10.2019: Fix UI problem when the number of workers increases too much (#140) *Guilherme Quirino*
 
 ## 1.4.0
 
-- 13.09.2019: Replace `chart.js` to `c3.js` (#139) _Guilherme Quirino_
-- 17.08.2019: Improve Date translations (#136) _Guilherme Quirino_
-- 05.08.2019: Add translation to FR (#135) _Wender Freese_
-- 02.08.2019: Add translation to JP (#133) _Emerson Araki_
-- 30.06.2019: Fix UI problem in realtime graphics when hided/showed (#130) _Wender Freese_
-- 28.06.2019: Fix UI problem in busy workers counter (#129) _Guilherme Quirino_
-- 24.06.2019: Update `chart.js` to V2 (#128) _Guilherme Quirino_
-- 11.05.2019: Add translations to PT-BR (#126) _Guilherme Quirino_
-- 08.03.2019: Change LogParser regexp (#81) _Kirill Tatchihin_
-- 03.02.2019: Change storing of last*runtime from date to timestamp (#87) \_Kirill Tatchihin*
-- 30.03.2017: Prevent excessive Redis memory usage (#107) _Gareth du Plooy_
-- 08.04.2016: Add new option for displaying last N lines of log file (#91) _Nick Zhebrun_
-- 20.11.2015: Convert value in redis time array to float (#76) _Anton Davydov_
-- 20.11.2015: Add Ukrainian Localization (#85) _@POStroi_
+* 13.09.2019: Replace `chart.js` to `c3.js` (#139) *Guilherme Quirino*
+* 17.08.2019: Improve Date translations (#136) *Guilherme Quirino*
+* 05.08.2019: Add translation to FR (#135) *Wender Freese*
+* 02.08.2019: Add translation to JP (#133) *Emerson Araki*
+* 30.06.2019: Fix UI problem in realtime graphics when hided/showed (#130) *Wender Freese*
+* 28.06.2019: Fix UI problem in busy workers counter (#129) *Guilherme Quirino*
+* 24.06.2019: Update `chart.js` to V2 (#128) *Guilherme Quirino*
+* 11.05.2019: Add translations to PT-BR (#126) *Guilherme Quirino*
+* 08.03.2019: Change LogParser regexp (#81) *Kirill Tatchihin*
+* 03.02.2019: Change storing of last_runtime from date to timestamp (#87) *Kirill Tatchihin*
+* 30.03.2017: Prevent excessive Redis memory usage (#107) *Gareth du Plooy*
+* 08.04.2016: Add new option for displaying last N lines of log file (#91) *Nick Zhebrun*
+* 20.11.2015: Convert value in redis time array to float (#76) *Anton Davydov*
+* 20.11.2015: Add Ukrainian Localization (#85) *@POStroi*
 
 ## v1.2
-
-- 15.11.2015: Update gemspec to allow usage with sidekiq 4 (#83) _Felix Bünemann_
-- 21.10.2015: Fix charts initialize and Uncaught TypeError (#70, #79) _Anton Davydov_
-- 17.10.2015: Fix worker's per day stats (#78) _Alexander Yunin_
-- 28.09.2015: Use strftime to ensure date string format (#77) _@stan_
-- 02.09.2015: Sort worker names in GUI (#69) _Anton Davydov_
+* 15.11.2015: Update gemspec to allow usage with sidekiq 4 (#83) *Felix Bünemann*
+* 21.10.2015: Fix charts initialize and Uncaught TypeError (#70, #79) *Anton Davydov*
+* 17.10.2015: Fix worker's per day stats (#78) *Alexander Yunin*
+* 28.09.2015: Use strftime to ensure date string format (#77) *@stan*
+* 02.09.2015: Sort worker names in GUI (#69) *Anton Davydov*
 
 ## v1.1
-
-- 29.08.2015: Create custom tooltip for charts on index page (fix #63) _Anton Davydov_
-- 26.08.2015: Add queue to workers table in index page _Anton Davydov_
-- 25.08.2015: Italian localization _Fabio Napoleoni_
-- 25.08.2015: Fix worker naming for AJ mailers (fix #59) _Anton Davydov_
-- 21.08.2015: Use dynamic path generation for json requests (fix #56) _Anton Davydov_
-- 21.08.2015: Add button in log page for display only special job (#40) _Anton Davydov_
-- 20.08.2015: Add German Localization (#54) _Felix Bünemann_
-- 20.08.2015: Fix statistics display for nested worker classes (#48) _Felix Bünemann_
+* 29.08.2015: Create custom tooltip for charts on index page (fix #63) *Anton Davydov*
+* 26.08.2015: Add queue to workers table in index page *Anton Davydov*
+* 25.08.2015: Italian localization *Fabio Napoleoni*
+* 25.08.2015: Fix worker naming for AJ mailers (fix #59) *Anton Davydov*
+* 21.08.2015: Use dynamic path generation for json requests (fix #56) *Anton Davydov*
+* 21.08.2015: Add button in log page for display only special job (#40) *Anton Davydov*
+* 20.08.2015: Add German Localization (#54) *Felix Bünemann*
+* 20.08.2015: Fix statistics display for nested worker classes (#48) *Felix Bünemann*
 
 ## v1.0
-
-- 19.08.2015: Middleware refactoring (#45) _Mike Perham_
-- 19.08.2015: Use redis lists for save all job runtimes _Anton Davydov_
-- 12.08.2015: Add filters (by worker) for realtime charts _Anton Davydov_
-- 11.08.2015: Realtime chart for each worker and job _Anton Davydov_
-- 31.07.2015: Add JSON API _Anton Davydov_
-- 29.07.2015: Add localizations for plugin _Anton Davydov_
-- 28.07.2015: Read first 1*000 lines from changelog \_Anton Davydov*
-- 28.07.2015: Rename plugin to sidekiq-statistic _Anton Davydov_
-- 23.07.2015: Use native redis hash instead json serialization _Anton Davydov_
-- 15.07.2015: Improve integration with active job _Anton Davydov_
-- 01.07.2015: New realisation for thread safe history middleware _Anton Davydov_
-- 13.05.2015: Add ability to change any date range on any history page _Anton Davydov_
-- 12.05.2015: Add last job status data parameter for each worker _Anton Davydov_
-- 11.05.2015: Add page woth worker data table for each day _Anton Davydov_
-- 28.04.2015: Formating worker date in web UI _Anton Davydov_
-- 27.04.2015: Set specific color for any worker _Anton Davydov_
-- 10.04.2015: Add search field on worker page _Anton Davydov_
-- 04.04.2015: Fix livereload button in index page _Anton Davydov_
-- 23.03.2015: Add max runtime column to worker web table _Anton Davydov_
-- 19.03.2015: Add functionality for adding custom css and js files to web page _Anton Davydov_
-- 18.03.2015: Add configuration class with log*file options \_Anton Davydov*
-- 16.03.2015: Add worker page where user can see log for this worker _Anton Davydov_
-- 15.03.2015: Add worker statistic table to index history page _Anton Davydov_
-- 08.03.2015: Add charts for each passed and failed jobs for each worker. _Anton Davydov_
-- 08.03.2015: Add Statistic class which provide statistics for each day and each worker. _Anton Davydov_
-- 08.03.2015: Save in redis json with failed and passed jobs for each worker. _Anton Davydov_
-- 04.03.2015: Created simple midelware and static page. _Anton Davydov_
+* 19.08.2015: Middleware refactoring (#45) *Mike Perham*
+* 19.08.2015: Use redis lists for save all job runtimes *Anton Davydov*
+* 12.08.2015: Add filters (by worker) for realtime charts *Anton Davydov*
+* 11.08.2015: Realtime chart for each worker and job *Anton Davydov*
+* 31.07.2015: Add JSON API *Anton Davydov*
+* 29.07.2015: Add localizations for plugin *Anton Davydov*
+* 28.07.2015: Read first 1_000 lines from changelog *Anton Davydov*
+* 28.07.2015: Rename plugin to sidekiq-statistic *Anton Davydov*
+* 23.07.2015: Use native redis hash instead json serialization *Anton Davydov*
+* 15.07.2015: Improve integration with active job *Anton Davydov*
+* 01.07.2015: New realisation for thread safe history middleware *Anton Davydov*
+* 13.05.2015: Add ability to change any date range on any history page *Anton Davydov*
+* 12.05.2015: Add last job status data parameter for each worker *Anton Davydov*
+* 11.05.2015: Add page woth worker data table for each day *Anton Davydov*
+* 28.04.2015: Formating worker date in web UI *Anton Davydov*
+* 27.04.2015: Set specific color for any worker *Anton Davydov*
+* 10.04.2015: Add search field on worker page *Anton Davydov*
+* 04.04.2015: Fix livereload button in index page *Anton Davydov*
+* 23.03.2015: Add max runtime column to worker web table *Anton Davydov*
+* 19.03.2015: Add functionality for adding custom css and js files to web page *Anton Davydov*
+* 18.03.2015: Add configuration class with log_file options *Anton Davydov*
+* 16.03.2015: Add worker page where user can see log for this worker *Anton Davydov*
+* 15.03.2015: Add worker statistic table to index history page *Anton Davydov*
+* 08.03.2015: Add charts for each passed and failed jobs for each worker. *Anton Davydov*
+* 08.03.2015: Add Statistic class which provide statistics for each day and each worker. *Anton Davydov*
+* 08.03.2015: Save in redis json with failed and passed jobs for each worker. *Anton Davydov*
+* 04.03.2015: Created simple midelware and static page. *Anton Davydov*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## HEAD
 
-- 25.08.2020: Improve dark mode workers table links readability(#160) _V-Gutierrez_
+- 02.09.2020: Improve dark mode workers table links readability(#160) _V-Gutierrez_
 - 25.08.2020: Refactor realtime statistic JS code (#159) _kostadriano_
 - 24.08.2020: Fix translation pt-Br start/stop (#153) _brunnohenrique_
 - 01.07.2020: Update workers toggle visibility button on RealTime (#156) _kostadriano_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,72 +1,76 @@
 ## HEAD
 
-* 25.08.2020: Refactor realtime statistic JS code (#159) *kostadriano*
-* 24.08.2020: Fix translation pt-Br start/stop (#153) *brunnohenrique*
-* 01.07.2020: Update workers toggle visibility button on RealTime (#156) *kostadriano*
-* 06.12.2019: Avoid whites when generating colors (#141) *Wender Freese*
-* 25.11.2019: Add line break in log visualization *Dmitriy*
-* 25.11.2019: Fix high memory usage in Log Parser *Dmitriy*
-* 04.10.2019: Fix UI problem when the number of workers increases too much (#140) *Guilherme Quirino*
+- 25.08.2020: Improve dark mode workers table links readability(#160) _V-Gutierrez_
+- 25.08.2020: Refactor realtime statistic JS code (#159) _kostadriano_
+- 24.08.2020: Fix translation pt-Br start/stop (#153) _brunnohenrique_
+- 01.07.2020: Update workers toggle visibility button on RealTime (#156) _kostadriano_
+- 06.12.2019: Avoid whites when generating colors (#141) _Wender Freese_
+- 25.11.2019: Add line break in log visualization _Dmitriy_
+- 25.11.2019: Fix high memory usage in Log Parser _Dmitriy_
+- 04.10.2019: Fix UI problem when the number of workers increases too much (#140) _Guilherme Quirino_
 
 ## 1.4.0
 
-* 13.09.2019: Replace `chart.js` to `c3.js` (#139) *Guilherme Quirino*
-* 17.08.2019: Improve Date translations (#136) *Guilherme Quirino*
-* 05.08.2019: Add translation to FR (#135) *Wender Freese*
-* 02.08.2019: Add translation to JP (#133) *Emerson Araki*
-* 30.06.2019: Fix UI problem in realtime graphics when hided/showed (#130) *Wender Freese*
-* 28.06.2019: Fix UI problem in busy workers counter (#129) *Guilherme Quirino*
-* 24.06.2019: Update `chart.js` to V2 (#128) *Guilherme Quirino*
-* 11.05.2019: Add translations to PT-BR (#126) *Guilherme Quirino*
-* 08.03.2019: Change LogParser regexp (#81) *Kirill Tatchihin*
-* 03.02.2019: Change storing of last_runtime from date to timestamp (#87) *Kirill Tatchihin*
-* 30.03.2017: Prevent excessive Redis memory usage (#107) *Gareth du Plooy*
-* 08.04.2016: Add new option for displaying last N lines of log file (#91) *Nick Zhebrun*
-* 20.11.2015: Convert value in redis time array to float (#76) *Anton Davydov*
-* 20.11.2015: Add Ukrainian Localization (#85) *@POStroi*
+- 13.09.2019: Replace `chart.js` to `c3.js` (#139) _Guilherme Quirino_
+- 17.08.2019: Improve Date translations (#136) _Guilherme Quirino_
+- 05.08.2019: Add translation to FR (#135) _Wender Freese_
+- 02.08.2019: Add translation to JP (#133) _Emerson Araki_
+- 30.06.2019: Fix UI problem in realtime graphics when hided/showed (#130) _Wender Freese_
+- 28.06.2019: Fix UI problem in busy workers counter (#129) _Guilherme Quirino_
+- 24.06.2019: Update `chart.js` to V2 (#128) _Guilherme Quirino_
+- 11.05.2019: Add translations to PT-BR (#126) _Guilherme Quirino_
+- 08.03.2019: Change LogParser regexp (#81) _Kirill Tatchihin_
+- 03.02.2019: Change storing of last*runtime from date to timestamp (#87) \_Kirill Tatchihin*
+- 30.03.2017: Prevent excessive Redis memory usage (#107) _Gareth du Plooy_
+- 08.04.2016: Add new option for displaying last N lines of log file (#91) _Nick Zhebrun_
+- 20.11.2015: Convert value in redis time array to float (#76) _Anton Davydov_
+- 20.11.2015: Add Ukrainian Localization (#85) _@POStroi_
 
 ## v1.2
-* 15.11.2015: Update gemspec to allow usage with sidekiq 4 (#83) *Felix Bünemann*
-* 21.10.2015: Fix charts initialize and Uncaught TypeError (#70, #79) *Anton Davydov*
-* 17.10.2015: Fix worker's per day stats (#78) *Alexander Yunin*
-* 28.09.2015: Use strftime to ensure date string format (#77) *@stan*
-* 02.09.2015: Sort worker names in GUI (#69) *Anton Davydov*
+
+- 15.11.2015: Update gemspec to allow usage with sidekiq 4 (#83) _Felix Bünemann_
+- 21.10.2015: Fix charts initialize and Uncaught TypeError (#70, #79) _Anton Davydov_
+- 17.10.2015: Fix worker's per day stats (#78) _Alexander Yunin_
+- 28.09.2015: Use strftime to ensure date string format (#77) _@stan_
+- 02.09.2015: Sort worker names in GUI (#69) _Anton Davydov_
 
 ## v1.1
-* 29.08.2015: Create custom tooltip for charts on index page (fix #63) *Anton Davydov*
-* 26.08.2015: Add queue to workers table in index page *Anton Davydov*
-* 25.08.2015: Italian localization *Fabio Napoleoni*
-* 25.08.2015: Fix worker naming for AJ mailers (fix #59) *Anton Davydov*
-* 21.08.2015: Use dynamic path generation for json requests (fix #56) *Anton Davydov*
-* 21.08.2015: Add button in log page for display only special job (#40) *Anton Davydov*
-* 20.08.2015: Add German Localization (#54) *Felix Bünemann*
-* 20.08.2015: Fix statistics display for nested worker classes (#48) *Felix Bünemann*
+
+- 29.08.2015: Create custom tooltip for charts on index page (fix #63) _Anton Davydov_
+- 26.08.2015: Add queue to workers table in index page _Anton Davydov_
+- 25.08.2015: Italian localization _Fabio Napoleoni_
+- 25.08.2015: Fix worker naming for AJ mailers (fix #59) _Anton Davydov_
+- 21.08.2015: Use dynamic path generation for json requests (fix #56) _Anton Davydov_
+- 21.08.2015: Add button in log page for display only special job (#40) _Anton Davydov_
+- 20.08.2015: Add German Localization (#54) _Felix Bünemann_
+- 20.08.2015: Fix statistics display for nested worker classes (#48) _Felix Bünemann_
 
 ## v1.0
-* 19.08.2015: Middleware refactoring (#45) *Mike Perham*
-* 19.08.2015: Use redis lists for save all job runtimes *Anton Davydov*
-* 12.08.2015: Add filters (by worker) for realtime charts *Anton Davydov*
-* 11.08.2015: Realtime chart for each worker and job *Anton Davydov*
-* 31.07.2015: Add JSON API *Anton Davydov*
-* 29.07.2015: Add localizations for plugin *Anton Davydov*
-* 28.07.2015: Read first 1_000 lines from changelog *Anton Davydov*
-* 28.07.2015: Rename plugin to sidekiq-statistic *Anton Davydov*
-* 23.07.2015: Use native redis hash instead json serialization *Anton Davydov*
-* 15.07.2015: Improve integration with active job *Anton Davydov*
-* 01.07.2015: New realisation for thread safe history middleware *Anton Davydov*
-* 13.05.2015: Add ability to change any date range on any history page *Anton Davydov*
-* 12.05.2015: Add last job status data parameter for each worker *Anton Davydov*
-* 11.05.2015: Add page woth worker data table for each day *Anton Davydov*
-* 28.04.2015: Formating worker date in web UI *Anton Davydov*
-* 27.04.2015: Set specific color for any worker *Anton Davydov*
-* 10.04.2015: Add search field on worker page *Anton Davydov*
-* 04.04.2015: Fix livereload button in index page *Anton Davydov*
-* 23.03.2015: Add max runtime column to worker web table *Anton Davydov*
-* 19.03.2015: Add functionality for adding custom css and js files to web page *Anton Davydov*
-* 18.03.2015: Add configuration class with log_file options *Anton Davydov*
-* 16.03.2015: Add worker page where user can see log for this worker *Anton Davydov*
-* 15.03.2015: Add worker statistic table to index history page *Anton Davydov*
-* 08.03.2015: Add charts for each passed and failed jobs for each worker. *Anton Davydov*
-* 08.03.2015: Add Statistic class which provide statistics for each day and each worker. *Anton Davydov*
-* 08.03.2015: Save in redis json with failed and passed jobs for each worker. *Anton Davydov*
-* 04.03.2015: Created simple midelware and static page. *Anton Davydov*
+
+- 19.08.2015: Middleware refactoring (#45) _Mike Perham_
+- 19.08.2015: Use redis lists for save all job runtimes _Anton Davydov_
+- 12.08.2015: Add filters (by worker) for realtime charts _Anton Davydov_
+- 11.08.2015: Realtime chart for each worker and job _Anton Davydov_
+- 31.07.2015: Add JSON API _Anton Davydov_
+- 29.07.2015: Add localizations for plugin _Anton Davydov_
+- 28.07.2015: Read first 1*000 lines from changelog \_Anton Davydov*
+- 28.07.2015: Rename plugin to sidekiq-statistic _Anton Davydov_
+- 23.07.2015: Use native redis hash instead json serialization _Anton Davydov_
+- 15.07.2015: Improve integration with active job _Anton Davydov_
+- 01.07.2015: New realisation for thread safe history middleware _Anton Davydov_
+- 13.05.2015: Add ability to change any date range on any history page _Anton Davydov_
+- 12.05.2015: Add last job status data parameter for each worker _Anton Davydov_
+- 11.05.2015: Add page woth worker data table for each day _Anton Davydov_
+- 28.04.2015: Formating worker date in web UI _Anton Davydov_
+- 27.04.2015: Set specific color for any worker _Anton Davydov_
+- 10.04.2015: Add search field on worker page _Anton Davydov_
+- 04.04.2015: Fix livereload button in index page _Anton Davydov_
+- 23.03.2015: Add max runtime column to worker web table _Anton Davydov_
+- 19.03.2015: Add functionality for adding custom css and js files to web page _Anton Davydov_
+- 18.03.2015: Add configuration class with log*file options \_Anton Davydov*
+- 16.03.2015: Add worker page where user can see log for this worker _Anton Davydov_
+- 15.03.2015: Add worker statistic table to index history page _Anton Davydov_
+- 08.03.2015: Add charts for each passed and failed jobs for each worker. _Anton Davydov_
+- 08.03.2015: Add Statistic class which provide statistics for each day and each worker. _Anton Davydov_
+- 08.03.2015: Save in redis json with failed and passed jobs for each worker. _Anton Davydov_
+- 04.03.2015: Created simple midelware and static page. _Anton Davydov_

--- a/lib/sidekiq/statistic/views/sidekiq-statistic.css
+++ b/lib/sidekiq/statistic/views/sidekiq-statistic.css
@@ -1,4 +1,5 @@
-.statistic {}
+.statistic {
+}
 
 .statistic__datepicker {
   margin-top: 10px;
@@ -85,7 +86,8 @@
   background: rgba(0, 0, 0, 0.1);
 }
 
-.worker__toggle-visibility:focus, .worker__toggle-visibility:active {
+.worker__toggle-visibility:focus,
+.worker__toggle-visibility:active {
   outline: none !important;
   box-shadow: none;
 }
@@ -93,12 +95,12 @@
 #chartjs-tooltip {
   opacity: 1;
   position: absolute;
-  background: rgba(0, 0, 0, .7);
+  background: rgba(0, 0, 0, 0.7);
   color: white;
   padding: 3px;
   border-radius: 3px;
-  -webkit-transition: all .1s ease;
-  transition: all .1s ease;
+  -webkit-transition: all 0.1s ease;
+  transition: all 0.1s ease;
   pointer-events: none;
   -webkit-transform: translate(-50%, 0);
   transform: translate(-50%, 0);
@@ -116,7 +118,6 @@
   margin: 0 2px 0 5px;
 }
 
-
 /*!
  * jQuery UI Datepicker @VERSION
  * http://jqueryui.com
@@ -130,15 +131,15 @@
 
 .ui-datepicker {
   width: 17em;
-  padding: .2em .2em 0;
+  padding: 0.2em 0.2em 0;
   display: none;
   background-color: #fff;
-  border: 1px solid #d7d7d7
+  border: 1px solid #d7d7d7;
 }
 
 .ui-datepicker .ui-datepicker-header {
   position: relative;
-  padding: .2em 0
+  padding: 0.2em 0;
 }
 
 .ui-datepicker .ui-datepicker-prev,
@@ -146,28 +147,28 @@
   position: absolute;
   top: 2px;
   width: 1.8em;
-  height: 1.8em
+  height: 1.8em;
 }
 
 .ui-datepicker .ui-datepicker-prev-hover,
 .ui-datepicker .ui-datepicker-next-hover {
-  top: 1px
+  top: 1px;
 }
 
 .ui-datepicker .ui-datepicker-prev {
-  left: 2px
+  left: 2px;
 }
 
 .ui-datepicker .ui-datepicker-next {
-  right: 15px
+  right: 15px;
 }
 
 .ui-datepicker .ui-datepicker-prev-hover {
-  left: 1px
+  left: 1px;
 }
 
 .ui-datepicker .ui-datepicker-next-hover {
-  right: 15px
+  right: 15px;
 }
 
 .ui-datepicker .ui-datepicker-prev span,
@@ -177,163 +178,172 @@
   left: 50%;
   margin-left: -8px;
   top: 50%;
-  margin-top: -8px
+  margin-top: -8px;
 }
 
 .ui-datepicker .ui-datepicker-title {
   margin: 0 2.3em;
   line-height: 1.8em;
-  text-align: center
+  text-align: center;
 }
 
 .ui-datepicker .ui-datepicker-title select {
   font-size: 1em;
-  margin: 1px 0
+  margin: 1px 0;
 }
 
 .ui-datepicker select.ui-datepicker-month,
 .ui-datepicker select.ui-datepicker-year {
-  width: 45%
+  width: 45%;
 }
 
 .ui-datepicker table {
   width: 100%;
-  font-size: .9em;
+  font-size: 0.9em;
   border-collapse: collapse;
-  margin: 0 0 .4em
+  margin: 0 0 0.4em;
 }
 
 .ui-datepicker th {
-  padding: .7em .3em;
+  padding: 0.7em 0.3em;
   text-align: center;
   font-weight: 700;
-  border: 0
+  border: 0;
 }
 
 .ui-datepicker td {
   border: 0;
-  padding: 1px
+  padding: 1px;
 }
 
 .ui-datepicker td span,
 .ui-datepicker td a {
   display: block;
-  padding: .2em;
+  padding: 0.2em;
   text-align: right;
-  text-decoration: none
+  text-decoration: none;
 }
 
 .ui-datepicker .ui-datepicker-buttonpane {
   background-image: none;
-  margin: .7em 0 0;
-  padding: 0 .2em;
+  margin: 0.7em 0 0;
+  padding: 0 0.2em;
   border-left: 0;
   border-right: 0;
-  border-bottom: 0
+  border-bottom: 0;
 }
 
 .ui-datepicker .ui-datepicker-buttonpane button {
   float: right;
-  margin: .5em .2em .4em;
+  margin: 0.5em 0.2em 0.4em;
   cursor: pointer;
-  padding: .2em .6em .3em;
+  padding: 0.2em 0.6em 0.3em;
   width: auto;
-  overflow: visible
+  overflow: visible;
 }
 
 .ui-datepicker .ui-datepicker-buttonpane button.ui-datepicker-current {
-  float: left
+  float: left;
 }
 
 .ui-datepicker.ui-datepicker-multi {
-  width: auto
+  width: auto;
 }
 
 .ui-datepicker-multi .ui-datepicker-group {
-  float: left
+  float: left;
 }
 
 .ui-datepicker-multi .ui-datepicker-group table {
   width: 95%;
-  margin: 0 auto .4em
+  margin: 0 auto 0.4em;
 }
 
 .ui-datepicker-multi-2 .ui-datepicker-group {
-  width: 50%
+  width: 50%;
 }
 
 .ui-datepicker-multi-3 .ui-datepicker-group {
-  width: 33.3%
+  width: 33.3%;
 }
 
 .ui-datepicker-multi-4 .ui-datepicker-group {
-  width: 25%
+  width: 25%;
 }
 
 .ui-datepicker-multi .ui-datepicker-group-last .ui-datepicker-header,
 .ui-datepicker-multi .ui-datepicker-group-middle .ui-datepicker-header {
-  border-left-width: 0
+  border-left-width: 0;
 }
 
 .ui-datepicker-multi .ui-datepicker-buttonpane {
-  clear: left
+  clear: left;
 }
 
 .ui-datepicker-row-break {
   clear: both;
   width: 100%;
-  font-size: 0
+  font-size: 0;
 }
 
 .ui-datepicker-rtl {
-  direction: rtl
+  direction: rtl;
 }
 
 .ui-datepicker-rtl .ui-datepicker-prev {
   right: 2px;
-  left: auto
+  left: auto;
 }
 
 .ui-datepicker-rtl .ui-datepicker-next {
   left: 2px;
-  right: auto
+  right: auto;
 }
 
 .ui-datepicker-rtl .ui-datepicker-prev:hover {
   right: 1px;
-  left: auto
+  left: auto;
 }
 
 .ui-datepicker-rtl .ui-datepicker-next:hover {
   left: 1px;
-  right: auto
+  right: auto;
 }
 
 .ui-datepicker-rtl .ui-datepicker-buttonpane {
-  clear: right
+  clear: right;
 }
 
 .ui-datepicker-rtl .ui-datepicker-buttonpane button {
-  float: left
+  float: left;
 }
 
 .ui-datepicker-rtl .ui-datepicker-buttonpane button.ui-datepicker-current,
 .ui-datepicker-rtl .ui-datepicker-group {
-  float: right
+  float: right;
 }
 
 .ui-datepicker-rtl .ui-datepicker-group-last .ui-datepicker-header,
 .ui-datepicker-rtl .ui-datepicker-group-middle .ui-datepicker-header {
   border-right-width: 0;
-  border-left-width: 1px
+  border-left-width: 1px;
 }
 
-.ui-datepicker a:active,
-a:hover,
-a:visited {
-  color: #4b001a;
+@media (prefers-color-scheme: dark) {
+  .ui-datepicker a:active,
+  a:hover,
+  a:visited {
+    color: #ccc;
+  }
 }
 
+@media (prefers-color-scheme: light) {
+  .ui-datepicker a:active,
+  a:hover,
+  a:visited {
+    color: #4b001a;
+  }
+}
 
 /*!
  * C3.js
@@ -342,19 +352,19 @@ a:visited {
 
 .c3 svg {
   font: 10px sans-serif;
-  -webkit-tap-highlight-color: transparent
+  -webkit-tap-highlight-color: transparent;
 }
 
 .c3 line,
 .c3 path {
   fill: none;
-  stroke: #000
+  stroke: #000;
 }
 
 .c3 text {
   -webkit-user-select: none;
   -moz-user-select: none;
-  user-select: none
+  user-select: none;
 }
 
 .c3-bars path,
@@ -362,101 +372,101 @@ a:visited {
 .c3-legend-item-tile,
 .c3-xgrid-focus,
 .c3-ygrid {
-  shape-rendering: crispEdges
+  shape-rendering: crispEdges;
 }
 
 .c3-chart-arc path {
-  stroke: #fff
+  stroke: #fff;
 }
 
 .c3-chart-arc text {
   fill: #fff;
-  font-size: 13px
+  font-size: 13px;
 }
 
 .c3-grid line {
-  stroke: #aaa
+  stroke: #aaa;
 }
 
 .c3-grid text {
-  fill: #aaa
+  fill: #aaa;
 }
 
 .c3-xgrid,
 .c3-ygrid {
-  stroke-dasharray: 3 3
+  stroke-dasharray: 3 3;
 }
 
 .c3-text.c3-empty {
   fill: gray;
-  font-size: 2em
+  font-size: 2em;
 }
 
 .c3-line {
-  stroke-width: 1px
+  stroke-width: 1px;
 }
 
 .c3-circle._expanded_ {
   stroke-width: 1px;
-  stroke: #fff
+  stroke: #fff;
 }
 
 .c3-selected-circle {
   fill: #fff;
-  stroke-width: 2px
+  stroke-width: 2px;
 }
 
 .c3-bar {
-  stroke-width: 0
+  stroke-width: 0;
 }
 
 .c3-bar._expanded_ {
-  fill-opacity: .75
+  fill-opacity: 0.75;
 }
 
 .c3-target.c3-focused {
-  opacity: 1
+  opacity: 1;
 }
 
 .c3-target.c3-focused path.c3-line,
 .c3-target.c3-focused path.c3-step {
-  stroke-width: 2px
+  stroke-width: 2px;
 }
 
 .c3-target.c3-defocused {
-  opacity: .3!important
+  opacity: 0.3 !important;
 }
 
 .c3-region {
   fill: #4682b4;
-  fill-opacity: .1
+  fill-opacity: 0.1;
 }
 
 .c3-brush .extent {
-  fill-opacity: .1
+  fill-opacity: 0.1;
 }
 
 .c3-legend-item {
-  font-size: 12px
+  font-size: 12px;
 }
 
 .c3-legend-item-hidden {
-  opacity: .15
+  opacity: 0.15;
 }
 
 .c3-legend-background {
-  opacity: .75;
+  opacity: 0.75;
   fill: #fff;
   stroke: #d3d3d3;
-  stroke-width: 1
+  stroke-width: 1;
 }
 
 .c3-title {
-  font: 14px sans-serif
+  font: 14px sans-serif;
 }
 
 .c3-tooltip-container {
-  z-index: 10
+  z-index: 10;
 }
 
 .c3-tooltip {
@@ -467,11 +477,11 @@ a:visited {
   -webkit-box-shadow: 7px 7px 12px -9px #777;
   -moz-box-shadow: 7px 7px 12px -9px #777;
   box-shadow: 7px 7px 12px -9px #777;
-  opacity: .9
+  opacity: 0.9;
 }
 
 .c3-tooltip tr {
-  border: 1px solid #CCC
+  border: 1px solid #ccc;
 }
 
 .c3-tooltip th {
@@ -479,52 +489,52 @@ a:visited {
   font-size: 14px;
   padding: 2px 5px;
   text-align: left;
-  color: #FFF
+  color: #fff;
 }
 
 .c3-tooltip td {
   font-size: 13px;
   padding: 3px 6px;
   background-color: #fff;
-  border-left: 1px dotted #999
+  border-left: 1px dotted #999;
 }
 
-.c3-tooltip td>span {
+.c3-tooltip td > span {
   display: inline-block;
   width: 10px;
   height: 10px;
-  margin-right: 6px
+  margin-right: 6px;
 }
 
 .c3-tooltip td.value {
-  text-align: right
+  text-align: right;
 }
 
 .c3-area {
   stroke-width: 0;
-  opacity: .2
+  opacity: 0.2;
 }
 
 .c3-chart-arcs-title {
   dominant-baseline: middle;
-  font-size: 1.3em
+  font-size: 1.3em;
 }
 
 .c3-chart-arcs .c3-chart-arcs-background {
   fill: #e0e0e0;
-  stroke: none
+  stroke: none;
 }
 
 .c3-chart-arcs .c3-chart-arcs-gauge-unit {
   fill: #000;
-  font-size: 16px
+  font-size: 16px;
 }
 
 .c3-chart-arcs .c3-chart-arcs-gauge-max,
 .c3-chart-arcs .c3-chart-arcs-gauge-min {
-  fill: #777
+  fill: #777;
 }
 
 .c3-chart-arc .c3-gauge-value {
-  fill: #000
+  fill: #000;
 }


### PR DESCRIPTION
Closes #160 

Improved visited anchors in worker table readability in dark mode

Changes are only applied to dark mode, I isolated dark and light mode settings with media queries what will make it easy to change it could be desired in the future

Before: 
![Screenshot_20200902_151505](https://user-images.githubusercontent.com/62355596/92028065-6e6c6780-ed31-11ea-99f7-4f9bc5061414.png)

After: 
![Screenshot_20200902_152619](https://user-images.githubusercontent.com/62355596/92028094-79bf9300-ed31-11ea-95e7-12968adb435f.png)


Light mode stills the same: 
![Screenshot_20200902_152640](https://user-images.githubusercontent.com/62355596/92029357-69a8b300-ed33-11ea-9893-51f33ffd2257.png)
