### PR TITLE
Refactoring middleware in order to keep responsibilities isolated

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,9 @@ This hash has the following structure:
 * `sidekiq:statistic` - redis hash with all statistic
   - `yyyy-mm-dd:WorkerName:passed` - count of passed jobs for Worker name on yyyy-mm-dd
   - `yyyy-mm-dd:WorkerName:failed` - count of failed jobs for Worker name on yyyy-mm-dd
-  - `yyyy-mm-dd:WorkerName:failed` - count of failed jobs for Worker name on yyyy-mm-dd
   - `yyyy-mm-dd:WorkerName:last_job_status` - string with status (`passed` or `failed`) for last job
-  - `yyyy-mm-dd:WorkerName:last_time` - date of lact job performing
-  - `yyyy-mm-dd:WorkerName:queue` - name of job queue (`defauld` by default)
+  - `yyyy-mm-dd:WorkerName:last_time` - date of last job performing
+  - `yyyy-mm-dd:WorkerName:queue` - name of job queue (`default` by default)
 
 For time information you should push the runtime value to `yyyy-mm-dd:WorkerName:timeslist` redis list.
 

--- a/lib/sidekiq/statistic.rb
+++ b/lib/sidekiq/statistic.rb
@@ -9,6 +9,9 @@ end
 require 'sidekiq/api'
 require 'sidekiq/statistic/configuration'
 require 'sidekiq/statistic/log_parser'
+require 'sidekiq/statistic/statistic/metric'
+require 'sidekiq/statistic/statistic/metrics/cache_keys'
+require 'sidekiq/statistic/statistic/metrics/store'
 require 'sidekiq/statistic/middleware'
 require 'sidekiq/statistic/base'
 require 'sidekiq/statistic/statistic/charts'
@@ -24,8 +27,6 @@ require 'sidekiq/statistic/helpers/date'
 
 module Sidekiq
   module Statistic
-    REDIS_HASH = 'sidekiq:statistic'
-
     class << self
       attr_writer :configuration
     end

--- a/lib/sidekiq/statistic/base.rb
+++ b/lib/sidekiq/statistic/base.rb
@@ -31,7 +31,7 @@ module Sidekiq
 
       def get_statistic_hash(conn, redis_hash)
         conn
-          .hgetall(REDIS_HASH)
+          .hgetall(Metrics::Store::REDIS_HASH)
           .each do |keys, value|
             *keys, last = keys.split(KEY_SEPARATOR)
             keys.inject(redis_hash, &key_or_empty_hash)[last.to_sym] = to_number(value)
@@ -85,7 +85,7 @@ module Sidekiq
         statistics = time_statistics(timeslist)
 
         Sidekiq.redis do |redis|
-          redis.hmset REDIS_HASH,
+          redis.hmset Metrics::Store::REDIS_HASH,
             statistics.flat_map{ |(k, v)| ["#{worker_key}:#{k}", v] }
         end
 

--- a/lib/sidekiq/statistic/middleware.rb
+++ b/lib/sidekiq/statistic/middleware.rb
@@ -3,58 +3,23 @@
 module Sidekiq
   module Statistic
     class Middleware
-      attr_accessor :msg
+      def call(worker, message, queue)
+        class_name = message['wrapped'] || worker.class.to_s
 
-      def call(worker, msg, queue)
-        worker_status = { last_job_status: 'passed' }
-        start = Time.now
+        metric = Metric.for(class_name: class_name, arguments: message['args'])
+        metric.queue = message['queue'] || queue
+        metric.start
 
         yield
       rescue => e
-        worker_status[:last_job_status] = 'failed'
+        metric.fails!
 
         raise e
       ensure
-        finish = Time.now
-        worker_status[:queue] = msg['queue']
-        worker_status[:last_runtime] = finish.utc.to_i
-        worker_status[:time] = (finish - start).to_f.round(3)
-        worker_status[:class] = msg['wrapped'] || worker.class.to_s
-        if worker_status[:class] == 'ActionMailer::DeliveryJob'
-          worker_status[:class] = msg['args'].first['arguments'].first
-        end
+        metric.finish
 
-        save_entry_for_worker worker_status
+        Metrics::Store.call(metric)
       end
-
-      def save_entry_for_worker(worker_status)
-        status = worker_status.dup
-        time = Time.at(worker_status[:last_runtime]).utc
-        realtime_hash = "#{REDIS_HASH}:realtime:#{time.sec}"
-        worker_key = "#{time.strftime "%Y-%m-%d"}:#{status.delete :class}"
-        timeslist_key = "#{worker_key}:timeslist"
-        times_list_length = nil
-        max_timelist_length = Sidekiq::Statistic.configuration.max_timelist_length
-
-        Sidekiq.redis do |redis|
-          redis.pipelined do
-            redis.hincrby REDIS_HASH, "#{worker_key}:#{status[:last_job_status]}", 1
-            redis.hmset REDIS_HASH, "#{worker_key}:last_job_status", status[:last_job_status],
-                                    "#{worker_key}:last_time", status[:last_runtime],
-                                    "#{worker_key}:queue", status[:queue]
-            times_list_length = redis.lpush timeslist_key, status[:time]
-
-            redis.hincrby realtime_hash, "#{status[:last_job_status]}:#{worker_status[:class]}", 1
-            redis.expire realtime_hash, 2
-          end
-
-          # Drop the oldest 25% of timing values if required to prevent Redis memory issues
-          if times_list_length.value > max_timelist_length
-            redis.ltrim(timeslist_key, 0, (max_timelist_length * 0.75).to_i)
-          end
-        end
-      end
-
     end
   end
 end

--- a/lib/sidekiq/statistic/statistic/metric.rb
+++ b/lib/sidekiq/statistic/statistic/metric.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Sidekiq
+  module Statistic
+    class Metric
+      JOB_MAILER_ID = 'ActionMailer::DeliveryJob'
+      STATUSES = {
+        success: :passed,
+        failure: :failed
+      }.freeze
+
+      def self.for(class_name:, arguments: [])
+        if class_name == JOB_MAILER_ID
+          clazz_from_mailer = arguments
+            .first['arguments']
+            .first
+
+          new(clazz_from_mailer)
+        else
+          new(class_name)
+        end
+      end
+
+      attr_accessor :queue, :status
+      attr_reader :class_name, :finished_at
+
+      def initialize(class_name)
+        @class_name = class_name
+        @status = STATUSES[:success]
+        @queue = 'default'
+
+        Time.now.utc.tap do |t|
+          @started_at = t
+          @finished_at = t
+        end
+      end
+
+      def fails!
+        @status = STATUSES[:failure]
+      end
+
+      def start
+        @started_at = Time.now.utc
+      end
+
+      def finish
+        @finished_at = Time.now.utc
+      end
+
+      def duration
+        (@finished_at - @started_at).to_f.round(3)
+      end
+    end
+  end
+end

--- a/lib/sidekiq/statistic/statistic/metrics/cache_keys.rb
+++ b/lib/sidekiq/statistic/statistic/metrics/cache_keys.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Sidekiq
+  module Statistic
+    module Metrics
+      class CacheKeys
+        def initialize(metric)
+          @metric = metric
+        end
+
+        def status
+          format([key, metric.status])
+        end
+
+        def class_name
+          format([metric.status, metric.class_name])
+        end
+
+        def last_job_status
+          format([key, 'last_job_status'])
+        end
+
+        def last_time
+          format([key, 'last_time'])
+        end
+
+        def queue
+          format([key, 'queue'])
+        end
+
+        def timeslist
+          format([key, 'timeslist'])
+        end
+
+        def realtime
+          format([Store::REDIS_HASH, 'realtime', metric.finished_at.utc.sec])
+        end
+
+        private
+
+        attr_reader :metric
+
+        def key
+          datetime = metric.finished_at.utc
+
+          format(
+            [
+              datetime.strftime('%Y-%m-%d'), metric.class_name
+            ]
+          )
+        end
+
+        def format(arr)
+          arr.join(':')
+        end
+      end
+    end
+  end
+end

--- a/lib/sidekiq/statistic/statistic/metrics/store.rb
+++ b/lib/sidekiq/statistic/statistic/metrics/store.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Sidekiq
+  module Statistic
+    module Metrics
+      class Store
+        REDIS_HASH = 'sidekiq:statistic'
+
+        def self.call(metric)
+          new(metric).call
+        end
+
+        def initialize(metric)
+          @metric = metric
+          @keys = CacheKeys.new(metric)
+        end
+
+        def call
+          cache_length = 0
+
+          Sidekiq.redis do |redis|
+            redis.pipelined { cache_length = store_cache_metrics(redis) }
+
+            release_cache_allocation(redis, cache_length)
+          end
+        end
+
+        private
+
+        def store_cache_metrics(redis)
+          redis.hincrby(REDIS_HASH, @keys.status, 1)
+
+          redis.hmset(REDIS_HASH, @keys.last_job_status, @metric.status,
+                                  @keys.last_time, @metric.finished_at.to_i,
+                                  @keys.queue, @metric.queue)
+
+          length = redis.lpush(@keys.timeslist, @metric.duration)
+
+          redis.hincrby(@keys.realtime, @keys.class_name, 1)
+          redis.expire(@keys.realtime, 2)
+
+          length
+        end
+
+        # The "timeslist" stores an array of decimal numbers representing
+        # the time in seconds for a worker duration time.
+        #
+        # Whenever the "timeslist" exceeds the stipulated max length it is
+        # going to remove 25% of the last values inside the array.
+        #
+        # https://github.com/davydovanton/sidekiq-statistic/issues/73
+        def release_cache_allocation(redis, timelist_length)
+          max_timelist_length = Sidekiq::Statistic.configuration.max_timelist_length
+
+          if timelist_length.value > max_timelist_length
+            redis.ltrim(@keys.timeslist, 0, (max_timelist_length * 0.75).to_i)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/sidekiq/statistic/statistic/realtime.rb
+++ b/lib/sidekiq/statistic/statistic/realtime.rb
@@ -20,7 +20,7 @@ module Sidekiq
         Sidekiq.redis do |conn|
           redis_hash = {}
           conn
-            .hgetall("#{REDIS_HASH}:realtime:#{Time.now.sec - 1}")
+            .hgetall("#{Metrics::Store::REDIS_HASH}:realtime:#{Time.now.sec - 1}")
             .each do |keys, value|
               *keys, last = keys.split(KEY_SEPARATOR)
               keys.inject(redis_hash, &key_or_empty_hash)[last] = value.to_i

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -39,6 +39,12 @@ module Nested
   end
 end
 
+def travel_to(time)
+  Time.stub :now, time do
+    yield
+  end
+end
+
 def middlewared(worker_class = HistoryWorker, msg = {})
   middleware = Sidekiq::Statistic::Middleware.new
   middleware.call worker_class.new, msg, 'default' do

--- a/test/statistic/metric_test.rb
+++ b/test/statistic/metric_test.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'minitest_helper'
+
+describe Sidekiq::Statistic::Metric do
+  describe '.for' do
+    describe 'when running "ActionMailer" jobs' do
+      it 'extracts class name from "args"' do
+        instance = Sidekiq::Statistic::Metric.for(
+          class_name: 'ActionMailer::DeliveryJob',
+          arguments: [
+            { 'arguments' => ['MyWorkerClass'] }
+          ]
+        )
+
+        assert_equal 'MyWorkerClass', instance.class_name
+      end
+    end
+
+    describe 'when running common jobs' do
+      it 'does not try to extract class name from "args"' do
+        instance = Sidekiq::Statistic::Metric.for(
+          class_name: 'MyWorkerClass'
+        )
+
+        assert_equal 'MyWorkerClass', instance.class_name
+      end
+    end
+  end
+
+  describe '#status' do
+    it 'assigns "default" for "status" attribute' do
+      instance = Sidekiq::Statistic::Metric.new('MyWorkerClass')
+
+      assert_equal :passed, instance.status
+    end
+  end
+
+  describe '#status=' do
+    it 'assigns given value for "status" attribute' do
+      instance = Sidekiq::Statistic::Metric.new('MyWorkerClass')
+
+      assert_equal :passed, instance.status
+
+      instance.status = Sidekiq::Statistic::Metric::STATUSES[:failure]
+
+      assert_equal :failed, instance.status
+    end
+  end
+
+  describe '#queue' do
+    it 'assigns "default" for "queue" attribute' do
+      instance = Sidekiq::Statistic::Metric.new('MyWorkerClass')
+
+      assert_equal 'default', instance.queue
+    end
+  end
+
+  describe '#queue=' do
+    it 'assigns given value for "queue" attribute' do
+      instance = Sidekiq::Statistic::Metric.new('MyWorkerClass')
+
+      assert_equal 'default', instance.queue
+
+      instance.queue = 'test'
+
+      assert_equal 'test', instance.queue
+    end
+  end
+
+  describe '#finished_at' do
+    it 'assigns current time for "finished_at" attribute' do
+      travel_to Time.new(2021, 1, 17, 14, 00, 00) do
+        instance = Sidekiq::Statistic::Metric.new('MyWorkerClass')
+
+        assert_equal Time.new(2021, 1, 17, 14, 00, 00), instance.finished_at
+      end
+    end
+  end
+
+  describe '#fails!' do
+    it 'assigns failure for status' do
+      instance = Sidekiq::Statistic::Metric.new('MyWorkerClass')
+
+      assert_equal :passed, instance.status
+
+      instance.fails!
+
+      assert_equal :failed, instance.status      
+    end
+  end
+
+  describe '#duration' do
+    it 'returns the difference between start and finish' do
+      instance = nil
+
+      travel_to Time.new(2021, 1, 17, 14, 00, 00) do
+        instance = Sidekiq::Statistic::Metric.new('MyWorkerClass')
+      end
+
+      travel_to Time.new(2021, 1, 17, 14, 10, 00) do
+        instance.start
+      end
+
+      travel_to Time.new(2021, 1, 17, 14, 12, 00) do
+        instance.finish
+      end
+
+      assert_equal 120, instance.duration
+    end
+  end
+end

--- a/test/statistic/metrics/cache_keys_test.rb
+++ b/test/statistic/metrics/cache_keys_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'minitest_helper'
+
+describe Sidekiq::Statistic::Metrics::CacheKeys do
+  describe '#status' do
+    describe 'for success status' do
+      let(:metric) { Sidekiq::Statistic::Metric.new('HistoryWorker') }
+
+      before do
+        metric.status = Sidekiq::Statistic::Metric::STATUSES[:success]
+      end
+
+      it 'returns correct key for "status" attribute' do
+        travel_to Time.new(2021, 1, 17, 14, 00, 00) do
+          result = Sidekiq::Statistic::Metrics::CacheKeys.new(metric)
+
+          assert_equal '2021-01-17:HistoryWorker:passed', result.status
+        end
+      end
+    end
+
+    describe 'for failure status' do
+      let(:metric) { Sidekiq::Statistic::Metric.new('HistoryWorker') }
+
+      before do
+        metric.status = Sidekiq::Statistic::Metric::STATUSES[:failure]
+      end
+
+      it 'returns correct key for "status" attribute' do
+        travel_to Time.new(2021, 1, 17, 14, 00, 00) do
+          result = Sidekiq::Statistic::Metrics::CacheKeys.new(metric)
+
+          assert_equal '2021-01-17:HistoryWorker:failed', result.status
+        end
+      end
+    end
+  end
+
+  describe '#class_name' do
+    let(:metric) { Sidekiq::Statistic::Metric.new('HistoryWorker') }
+
+    it 'returns correct key for "class_name" attribute' do
+      result = Sidekiq::Statistic::Metrics::CacheKeys.new(metric)
+
+      assert_equal 'passed:HistoryWorker', result.class_name
+    end
+  end
+
+  describe '#last_job_status' do
+    let(:metric) { Sidekiq::Statistic::Metric.new('HistoryWorker') }
+
+    it 'returns correct key for "last_job_status" attribute' do
+      travel_to Time.new(2021, 1, 17, 14, 00, 00) do
+        result = Sidekiq::Statistic::Metrics::CacheKeys.new(metric)
+
+        assert_equal '2021-01-17:HistoryWorker:last_job_status', result.last_job_status
+      end
+    end
+  end
+
+  describe '#last_time' do
+    let(:metric) { Sidekiq::Statistic::Metric.new('HistoryWorker') }
+
+    it 'returns correct key for "last_time" attribute' do
+      travel_to Time.new(2021, 1, 17, 14, 00, 00) do
+        result = Sidekiq::Statistic::Metrics::CacheKeys.new(metric)
+
+        assert_equal '2021-01-17:HistoryWorker:last_time', result.last_time
+      end
+    end
+  end
+
+  describe '#queue' do
+    let(:metric) { Sidekiq::Statistic::Metric.new('HistoryWorker') }
+
+    it 'returns correct key for "queue" attribute' do
+      travel_to Time.new(2021, 1, 17, 14, 00, 00) do
+        result = Sidekiq::Statistic::Metrics::CacheKeys.new(metric)
+
+        assert_equal '2021-01-17:HistoryWorker:queue', result.queue
+      end
+    end
+  end
+
+  describe '#timeslist' do
+    let(:metric) { Sidekiq::Statistic::Metric.new('HistoryWorker') }
+
+    it 'returns correct key for "timeslist" attribute' do
+      travel_to Time.new(2021, 1, 17, 14, 00, 00) do
+        result = Sidekiq::Statistic::Metrics::CacheKeys.new(metric)
+
+        assert_equal '2021-01-17:HistoryWorker:timeslist', result.timeslist
+      end
+    end
+  end
+
+  describe '#realtime' do
+    let(:metric) { Sidekiq::Statistic::Metric.new('HistoryWorker') }
+
+    it 'returns correct key for "realtime" attribute' do
+      travel_to Time.new(2021, 1, 17, 14, 00, 00) do
+        result = Sidekiq::Statistic::Metrics::CacheKeys.new(metric)
+
+        assert_equal 'sidekiq:statistic:realtime:0', result.realtime
+      end
+    end
+  end
+end

--- a/test/statistic/metrics/store_test.rb
+++ b/test/statistic/metrics/store_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'minitest_helper'
+
+describe Sidekiq::Statistic::Metrics::Store do
+	# The behavior from this class is fully exercised on the
+	# integration test below:
+	#
+	# test/test_sidekiq/middleware_test.rb
+end

--- a/test/statistic/metrics/store_test.rb
+++ b/test/statistic/metrics/store_test.rb
@@ -3,8 +3,8 @@
 require 'minitest_helper'
 
 describe Sidekiq::Statistic::Metrics::Store do
-	# The behavior from this class is fully exercised on the
-	# integration test below:
-	#
-	# test/test_sidekiq/middleware_test.rb
+  # The behavior from this class is fully exercised on the
+  # integration test below:
+  #
+  # test/test_sidekiq/middleware_test.rb
 end

--- a/test/test_sidekiq/base_statistic_test.rb
+++ b/test/test_sidekiq/base_statistic_test.rb
@@ -36,14 +36,14 @@ module Sidekiq
             middlewared {}
 
             Sidekiq.redis do |conn|
-              assert_equal true, conn.hget(REDIS_HASH, "#{Time.now.utc.to_date}:HistoryWorker:total_time").nil?
+              assert_equal true, conn.hget(Metrics::Store::REDIS_HASH, "#{Time.now.utc.to_date}:HistoryWorker:total_time").nil?
               assert_equal 1, conn.lrange("#{Time.now.utc.to_date}:HistoryWorker:timeslist", 0, -1).size
             end
 
             base_statistic.statistic_hash
 
             Sidekiq.redis do |conn|
-              assert_equal false, conn.hget(REDIS_HASH, "#{Time.now.utc.to_date}:HistoryWorker:total_time").nil?
+              assert_equal false, conn.hget(Metrics::Store::REDIS_HASH, "#{Time.now.utc.to_date}:HistoryWorker:total_time").nil?
               assert_equal 0, conn.lrange("#{Time.now.utc.to_date}:HistoryWorker:timeslist", 0, -1).size
             end
           end
@@ -55,9 +55,9 @@ module Sidekiq
           middlewared {}
           time = Time.now.utc
 
-          Time.stub :now, time do
+          travel_to time do
             values = base_statistic.statistic_for('HistoryWorker')
-            assert_equal [{}, { passed: 1.0, last_job_status: "passed", last_time: time.to_i, queue: "", average_time: 0.0, min_time: 0.0, max_time: 0.0, total_time: 0.0, failed: 0 }], values
+            assert_equal [{}, { passed: 1.0, last_job_status: "passed", last_time: time.to_i, queue: "default", average_time: 0.0, min_time: 0.0, max_time: 0.0, total_time: 0.0, failed: 0 }], values
           end
         end
 

--- a/test/test_sidekiq/middleware_test.rb
+++ b/test/test_sidekiq/middleware_test.rb
@@ -12,12 +12,12 @@ module Sidekiq
 
       before { Sidekiq.redis(&:flushdb) }
 
-      let(:date){ Time.now.utc.to_date }
+      let(:date) { Time.now.utc.to_date }
       let(:actual) do
         Sidekiq.redis do |conn|
           redis_hash = {}
           conn
-            .hgetall(REDIS_HASH)
+            .hgetall(Metrics::Store::REDIS_HASH)
             .each do |keys, value|
               *keys, last = keys.split(":")
               keys.inject(redis_hash){ |hash, key| hash[key] || hash[key] = {} }[last.to_sym] = to_number(value)

--- a/test/test_sidekiq/realtime_test.rb
+++ b/test/test_sidekiq/realtime_test.rb
@@ -7,13 +7,13 @@ module Sidekiq
     describe 'Realtime' do
       before { Sidekiq.redis(&:flushdb) }
 
-      let(:realtime){ Sidekiq::Statistic::Realtime.new }
-      let(:current_time){ Time.new(2015, 8, 11, 23, 22, 21, "+00:00").utc }
+      let(:realtime) { Sidekiq::Statistic::Realtime.new }
+      let(:current_time) { Time.new(2015, 8, 11, 23, 22, 21, "+00:00").utc }
 
       describe '::charts_initializer' do
         describe 'before any jobs' do
           it 'returns initialize array for realtime chart' do
-            Time.stub :now, current_time do
+            travel_to current_time do
               initialize_array = Sidekiq::Statistic::Realtime.charts_initializer
               assert_equal [['x', '23:22:21', '23:22:20', '23:22:19', '23:22:18', '23:22:17', '23:22:16', '23:22:15', '23:22:14', '23:22:13', '23:22:12', '23:22:11', '23:22:10']], initialize_array
             end
@@ -22,11 +22,11 @@ module Sidekiq
 
         describe 'after job' do
           it 'returns initialize array for realtime chart' do
-            Time.stub :now, current_time - 1 do
+            travel_to current_time - 1 do
               middlewared {}
             end
 
-            Time.stub :now, current_time do
+            travel_to current_time do
               initialize_array = Sidekiq::Statistic::Realtime.charts_initializer
               assert_equal [['HistoryWorker', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], ['x', '23:22:21', '23:22:20', '23:22:19', '23:22:18', '23:22:17', '23:22:16', '23:22:15', '23:22:14', '23:22:13', '23:22:12', '23:22:11', '23:22:10']], initialize_array
             end
@@ -43,7 +43,7 @@ module Sidekiq
 
         describe 'after job' do
           it 'returns worker run count' do
-            Time.stub :now, (current_time - 1) do
+            travel_to (current_time - 1) do
               middlewared {}
 
               begin
@@ -54,7 +54,7 @@ module Sidekiq
               end
             end
 
-            Time.stub :now, current_time do
+            travel_to current_time do
               assert_equal({'passed'=>{'HistoryWorker'=>1}, 'failed'=>{'HistoryWorker'=>1}}, realtime.realtime_hash)
             end
           end
@@ -64,7 +64,7 @@ module Sidekiq
       describe '#statistic' do
         describe 'before any jobs' do
           it 'returns hash with empty values' do
-            Time.stub :now, current_time do
+            travel_to current_time do
               assert_equal({failed: {columns: [['x', '23:22:21']]}, passed: {columns: [['x', '23:22:21']]}}, realtime.statistic)
             end
           end
@@ -72,7 +72,7 @@ module Sidekiq
 
         describe 'after job' do
           it 'returns worker run count for each realtime chart' do
-            Time.stub :now, (current_time - 1) do
+            travel_to (current_time - 1) do
               middlewared {}
 
               begin
@@ -83,7 +83,7 @@ module Sidekiq
               end
             end
 
-            Time.stub :now, current_time do
+            travel_to current_time do
               assert_equal({failed: {columns: [['HistoryWorker', 1], ['x', '23:22:21']]}, passed: {columns: [['HistoryWorker', 1], ['x', '23:22:21']]}}, realtime.statistic)
             end
           end


### PR DESCRIPTION
## Motivation

- In order to start attending to new features present in `issues` section I decided to perform some refactorings to clean up the `middleware` module and isolate the responsibility present on it across other specialized modules.

## Changes

- Share `middleware.rb` responsibilities with new modules `metrics/store`, `statistic/metric.rb` and `metrics/cache_keys`
- Move `REDIS_HASH` to the `metrics/store` module
- Isolate `Time.stub` into a `travel_to` helper method
- Fix minor problems in `README.md`

## Next steps

- Refactor modules that fetch data from Redis in order to isolate them as well