### PR TITLE
Fix tests: Remove usage of before block together with Time.stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## HEAD
+* 02.02.2021: Fix tests *Kirill Tatchihin*
 * 02.09.2020: Improve dark mode workers table links readability(#160) *V-Gutierrez*
 * 25.08.2020: Refactor realtime statistic JS code (#159) *kostadriano*
 * 24.08.2020: Fix translation pt-Br start/stop (#153) *brunnohenrique*

--- a/test/statistic/metrics/cache_keys_test.rb
+++ b/test/statistic/metrics/cache_keys_test.rb
@@ -7,10 +7,6 @@ describe Sidekiq::Statistic::Metrics::CacheKeys do
     describe 'for success status' do
       let(:metric) { Sidekiq::Statistic::Metric.new('HistoryWorker') }
 
-      before do
-        metric.status = Sidekiq::Statistic::Metric::STATUSES[:success]
-      end
-
       it 'returns correct key for "status" attribute' do
         travel_to Time.new(2021, 1, 17, 14, 00, 00) do
           result = Sidekiq::Statistic::Metrics::CacheKeys.new(metric)
@@ -23,12 +19,9 @@ describe Sidekiq::Statistic::Metrics::CacheKeys do
     describe 'for failure status' do
       let(:metric) { Sidekiq::Statistic::Metric.new('HistoryWorker') }
 
-      before do
-        metric.status = Sidekiq::Statistic::Metric::STATUSES[:failure]
-      end
-
       it 'returns correct key for "status" attribute' do
         travel_to Time.new(2021, 1, 17, 14, 00, 00) do
+          metric.fails!
           result = Sidekiq::Statistic::Metrics::CacheKeys.new(metric)
 
           assert_equal '2021-01-17:HistoryWorker:failed', result.status


### PR DESCRIPTION
As far as we use `let` it lazy inits the `metric`. Also, in some tests we have `before` block. It calls metric before the test and do not allow to `Time.stub` block to be called before metric inits. I've removed `before` block to make the test works with `Time.stub` block
@davydovanton looks like previous PR was merged without tests passed :( 