### PR TITLE
[#113] Filter workers by their last job status

### DIFF
--- a/lib/sidekiq/statistic/statistic/workers.rb
+++ b/lib/sidekiq/statistic/statistic/workers.rb
@@ -17,6 +17,17 @@ module Sidekiq
         end
       end
 
+			def display_by_last_status
+				{
+					passed: filter_last_job_status('passed'),
+					failed: filter_last_job_status('failed')
+				}
+			end
+
+			def filter_last_job_status(status)
+				display.select { |worker| worker[:last_job_status] == status }
+			end
+
       def display_per_day(worker_name)
         statistic_hash.flat_map do |day|
           day.reject{ |_, workers| workers.empty? }.map do |date, workers|

--- a/lib/sidekiq/statistic/statistic/workers.rb
+++ b/lib/sidekiq/statistic/statistic/workers.rb
@@ -17,16 +17,16 @@ module Sidekiq
         end
       end
 
-			def display_by_last_status
-				{
-					passed: filter_last_job_status('passed'),
-					failed: filter_last_job_status('failed')
-				}
-			end
+      def display_by_last_status
+        {
+          passed: filter_last_job_status('passed'),
+          failed: filter_last_job_status('failed')
+        }
+      end
 
-			def filter_last_job_status(status)
-				display.select { |worker| worker[:last_job_status] == status }
-			end
+      def filter_last_job_status(status)
+        display.select { |worker| worker[:last_job_status] == status }
+      end
 
       def display_per_day(worker_name)
         statistic_hash.flat_map do |day|

--- a/lib/sidekiq/statistic/views/statistic.erb
+++ b/lib/sidekiq/statistic/views/statistic.erb
@@ -37,6 +37,7 @@
 
     <h2><%= t('WorkersTable') %></h2>
     <div id="status_filters_checkboxes">
+      <p><strong><%= t('LastJobStatus') %>:</strong></p>
       <p><input type="checkbox" id="show-passed" checked> <%= t('Passed') %></p>
       <p><input type="checkbox" id="show-failed" checked> <%= t('Failed') %></p>
     </div>

--- a/lib/sidekiq/statistic/views/statistic.erb
+++ b/lib/sidekiq/statistic/views/statistic.erb
@@ -37,8 +37,8 @@
 
     <h2><%= t('WorkersTable') %></h2>
     <div id="status_filters_checkboxes">
-      <p><input type="checkbox" id="show-passed" checked> Show passed</p>
-      <p><input type="checkbox" id="show-failed" checked> Show failed</p>
+      <p><input type="checkbox" id="show-passed" checked> <%= t('Passed') %></p>
+      <p><input type="checkbox" id="show-failed" checked> <%= t('Failed') %></p>
     </div>
     <table class="statistic__table table table-hover table-bordered table-striped table-white live-reload">
       <thead>

--- a/lib/sidekiq/statistic/views/statistic.erb
+++ b/lib/sidekiq/statistic/views/statistic.erb
@@ -36,10 +36,10 @@
     </div>
 
     <h2><%= t('WorkersTable') %></h2>
-		<div id="status_filters_checkboxes">
-			<p><input type="checkbox" id="show-passed" checked> Show passed</p>
-			<p><input type="checkbox" id="show-failed" checked> Show failed</p>
-		</div>
+    <div id="status_filters_checkboxes">
+      <p><input type="checkbox" id="show-passed" checked> Show passed</p>
+      <p><input type="checkbox" id="show-failed" checked> Show failed</p>
+    </div>
     <table class="statistic__table table table-hover table-bordered table-striped table-white live-reload">
       <thead>
         <th><%= t('Worker') %></th>
@@ -56,22 +56,22 @@
       </thead>
       <tbody>
       <% @all_workers.each do |worker| %>
-				<tr class="worker-<%= worker[:last_job_status] %>">
-					<td>
-						<a href="<%= root_path %>statistic/<%= worker[:name] %>"><%= worker[:name] %></a>
-					</td>
-					<td><%= format_date worker[:runtime][:last], 'datetime' %></td>
-					<td><%= worker[:queue] %></td>
-					<td><%= worker[:number_of_calls][:success] %></td>
-					<td><%= worker[:number_of_calls][:failure] %></td>
-					<td><%= worker[:number_of_calls][:total] %></td>
-					<td><%= worker[:runtime][:total] %></td>
-					<td><%= worker[:runtime][:average] %></td>
-					<td><%= worker[:runtime][:min] %></td>
-					<td><%= worker[:runtime][:max] %></td>
-					<td><%= worker[:last_job_status] %></td>
-				</tr>
-			<% end %>
+        <tr class="worker-<%= worker[:last_job_status] %>">
+          <td>
+            <a href="<%= root_path %>statistic/<%= worker[:name] %>"><%= worker[:name] %></a>
+          </td>
+          <td><%= format_date worker[:runtime][:last], 'datetime' %></td>
+          <td><%= worker[:queue] %></td>
+          <td><%= worker[:number_of_calls][:success] %></td>
+          <td><%= worker[:number_of_calls][:failure] %></td>
+          <td><%= worker[:number_of_calls][:total] %></td>
+          <td><%= worker[:runtime][:total] %></td>
+          <td><%= worker[:runtime][:average] %></td>
+          <td><%= worker[:runtime][:min] %></td>
+          <td><%= worker[:runtime][:max] %></td>
+          <td><%= worker[:last_job_status] %></td>
+        </tr>
+      <% end %>
       </tbody>
     </table>
   </div>

--- a/lib/sidekiq/statistic/views/statistic.erb
+++ b/lib/sidekiq/statistic/views/statistic.erb
@@ -36,6 +36,10 @@
     </div>
 
     <h2><%= t('WorkersTable') %></h2>
+		<div id="status_filters_checkboxes">
+			<p><input type="checkbox" id="show-passed" checked> Show passed</p>
+			<p><input type="checkbox" id="show-failed" checked> Show failed</p>
+		</div>
     <table class="statistic__table table table-hover table-bordered table-striped table-white live-reload">
       <thead>
         <th><%= t('Worker') %></th>
@@ -52,22 +56,22 @@
       </thead>
       <tbody>
       <% @all_workers.each do |worker| %>
-        <tr>
-          <td>
-            <a href="<%= root_path %>statistic/<%= worker[:name] %>"><%= worker[:name] %></a>
-          </td>
-          <td><%= format_date worker[:runtime][:last], 'datetime' %></td>
-          <td><%= worker[:queue] %></td>
-          <td><%= worker[:number_of_calls][:success] %></td>
-          <td><%= worker[:number_of_calls][:failure] %></td>
-          <td><%= worker[:number_of_calls][:total] %></td>
-          <td><%= worker[:runtime][:total] %></td>
-          <td><%= worker[:runtime][:average] %></td>
-          <td><%= worker[:runtime][:min] %></td>
-          <td><%= worker[:runtime][:max] %></td>
-          <td><%= worker[:last_job_status] %></td>
-        </tr>
-      <% end %>
+				<tr class="worker-<%= worker[:last_job_status] %>">
+					<td>
+						<a href="<%= root_path %>statistic/<%= worker[:name] %>"><%= worker[:name] %></a>
+					</td>
+					<td><%= format_date worker[:runtime][:last], 'datetime' %></td>
+					<td><%= worker[:queue] %></td>
+					<td><%= worker[:number_of_calls][:success] %></td>
+					<td><%= worker[:number_of_calls][:failure] %></td>
+					<td><%= worker[:number_of_calls][:total] %></td>
+					<td><%= worker[:runtime][:total] %></td>
+					<td><%= worker[:runtime][:average] %></td>
+					<td><%= worker[:runtime][:min] %></td>
+					<td><%= worker[:runtime][:max] %></td>
+					<td><%= worker[:last_job_status] %></td>
+				</tr>
+			<% end %>
       </tbody>
     </table>
   </div>

--- a/lib/sidekiq/statistic/views/statistic.js
+++ b/lib/sidekiq/statistic/views/statistic.js
@@ -35,6 +35,19 @@ $(function () {
     $($this.data('target')).show()
   })
 
+  $(document).on('click', '#status_filters_checkboxes', function (e) {
+		$('.worker-failed').hide()
+		$('.worker-passed').hide()
+
+    if($('#show-passed').is(":checked")) {
+			$('.worker-passed').show()
+		}
+
+    if($('#show-failed').is(":checked")) {
+			$('.worker-failed').show()
+		}
+  })
+
   $(document).on('click', '.statistic__jid', function (e) {
     $('.statistic__i').toggle()
     $($(this).data('target')).parent().show()

--- a/lib/sidekiq/statistic/views/statistic.js
+++ b/lib/sidekiq/statistic/views/statistic.js
@@ -36,16 +36,16 @@ $(function () {
   })
 
   $(document).on('click', '#status_filters_checkboxes', function (e) {
-		$('.worker-failed').hide()
-		$('.worker-passed').hide()
+    $('.worker-failed').hide()
+    $('.worker-passed').hide()
 
     if($('#show-passed').is(":checked")) {
-			$('.worker-passed').show()
-		}
+      $('.worker-passed').show()
+    }
 
     if($('#show-failed').is(":checked")) {
-			$('.worker-failed').show()
-		}
+      $('.worker-failed').show()
+    }
   })
 
   $(document).on('click', '.statistic__jid', function (e) {

--- a/lib/sidekiq/statistic/views/styles/common.css
+++ b/lib/sidekiq/statistic/views/styles/common.css
@@ -24,6 +24,18 @@
   float: right;
 }
 
+/* === INPUT LIST === */
+
+#status_filters_checkboxes {
+	display: flex;
+	gap: 2em;
+}
+
+#status_filters_checkboxes p {
+	display: inline;
+}
+
+
 /* === TABLES === */
 
 .statistic__table > tbody > tr > td {

--- a/lib/sidekiq/statistic/web_api_extension.rb
+++ b/lib/sidekiq/statistic/web_api_extension.rb
@@ -18,7 +18,7 @@ module Sidekiq
           Sidekiq.dump_json(workers: statistic.display)
         end
 
-        app.get '/api/statistic_by_state.json' do
+        app.get '/api/statistic_by_last_job_status.json' do
           statistic = Sidekiq::Statistic::Workers.new(*calculate_date_range(params))
           Sidekiq.dump_json(status: statistic.display_by_last_status)
         end

--- a/lib/sidekiq/statistic/web_api_extension.rb
+++ b/lib/sidekiq/statistic/web_api_extension.rb
@@ -18,6 +18,11 @@ module Sidekiq
           Sidekiq.dump_json(workers: statistic.display)
         end
 
+        app.get '/api/statistic_by_state.json' do
+          statistic = Sidekiq::Statistic::Workers.new(*calculate_date_range(params))
+          Sidekiq.dump_json(status: statistic.display_by_last_status)
+        end
+
         app.get '/api/statistic/:worker.json' do
           worker_statistic =
             Sidekiq::Statistic::Workers
@@ -25,11 +30,6 @@ module Sidekiq
               .display_per_day(params[:worker])
 
           Sidekiq.dump_json(days: worker_statistic)
-        end
-
-        app.get '/api/statistic_by_state.json' do
-          statistic = Sidekiq::Statistic::Workers.new(*calculate_date_range(params))
-          Sidekiq.dump_json(status: statistic.display_by_last_status)
         end
       end
     end

--- a/lib/sidekiq/statistic/web_api_extension.rb
+++ b/lib/sidekiq/statistic/web_api_extension.rb
@@ -26,6 +26,11 @@ module Sidekiq
 
           Sidekiq.dump_json(days: worker_statistic)
         end
+
+        app.get '/api/statistic_by_state.json' do
+          statistic = Sidekiq::Statistic::Workers.new(*calculate_date_range(params))
+          Sidekiq.dump_json(status: statistic.display_by_last_status)
+        end
       end
     end
   end

--- a/test/test_sidekiq/statistic_test.rb
+++ b/test/test_sidekiq/statistic_test.rb
@@ -111,31 +111,28 @@ module Sidekiq
           subject = statistic.display_by_last_status
 
           _(subject).must_be_instance_of Hash
-
           assert_equal subject.keys.sort,
                        %i[passed failed].sort
 
-					_(subject[:passed]).must_be_instance_of Array
-					_(subject[:failed]).must_be_instance_of Array
-
-					assert_equal subject[:passed][0].keys.sort,
-											%i[name last_job_status number_of_calls queue runtime].sort
+          _(subject[:passed]).must_be_instance_of Array
+          _(subject[:failed]).must_be_instance_of Array
+          assert_equal subject[:passed][0].keys.sort,
+                      %i[name last_job_status number_of_calls queue runtime].sort
 
           assert_equal worker, subject[:passed][0][:name]
         end
       end
 
-			describe "#filter_last_job_status" do
-				it 'return array with worker when filtering by passed workers' do
-					middlewared {}
+      describe "#filter_last_job_status" do
+        it 'return array with worker when filtering by passed workers' do
+          middlewared {}
 
           subject = statistic.filter_last_job_status('passed')
 
           _(subject).must_be_instance_of Array
-
-					assert_equal subject[0][:name], worker
-				end
-			end
+          assert_equal subject[0][:name], worker
+        end
+      end
 
       describe '#display_per_day' do
         it 'return workers job per day' do

--- a/test/test_sidekiq/statistic_test.rb
+++ b/test/test_sidekiq/statistic_test.rb
@@ -104,6 +104,39 @@ module Sidekiq
         end
       end
 
+      describe '#display_by_last_status' do
+        it 'return workers separated by their last status' do
+          middlewared {}
+
+          subject = statistic.display_by_last_status
+
+          _(subject).must_be_instance_of Hash
+
+          assert_equal subject.keys.sort,
+                       %i[passed failed].sort
+
+					_(subject[:passed]).must_be_instance_of Array
+					_(subject[:failed]).must_be_instance_of Array
+
+					assert_equal subject[:passed][0].keys.sort,
+											%i[name last_job_status number_of_calls queue runtime].sort
+
+          assert_equal worker, subject[:passed][0][:name]
+        end
+      end
+
+			describe "#filter_last_job_status" do
+				it 'return array with worker when filtering by passed workers' do
+					middlewared {}
+
+          subject = statistic.filter_last_job_status('passed')
+
+          _(subject).must_be_instance_of Array
+
+					assert_equal subject[0][:name], worker
+				end
+			end
+
       describe '#display_per_day' do
         it 'return workers job per day' do
           middlewared {}

--- a/test/test_sidekiq/web_api_extension_test.rb
+++ b/test/test_sidekiq/web_api_extension_test.rb
@@ -97,21 +97,21 @@ module Sidekiq
             get '/api/statistic_by_state.json?dateFrom=2015-07-28&dateTo=2015-07-29'
 
             response = Sidekiq.load_json(last_response.body)
-						_(response['status']).must_be_instance_of Hash
-						_(response['status']['passed']).must_equal []
-						_(response['status']['failed']).must_equal []
+            _(response['status']).must_be_instance_of Hash
+            _(response['status']['passed']).must_equal []
+            _(response['status']['failed']).must_equal []
           end
         end
 
         describe 'for any date range with existed statistic' do
-					it 'returns workers statistic filtered by state' do
+          it 'returns workers statistic filtered by state' do
             get "/api/statistic_by_state.json?dateFrom=2015-07-28&dateTo=#{Date.today}"
 
             response = Sidekiq.load_json(last_response.body)
-						_(response['status']).must_be_instance_of Hash
-						_(response['status']['passed']).wont_equal []
+            _(response['status']).must_be_instance_of Hash
+            _(response['status']['passed']).wont_equal []
             _(response['status']['passed'].count).must_equal 1
-						_(response['status']['failed']).must_equal []
+            _(response['status']['failed']).must_equal []
           end
         end
       end

--- a/test/test_sidekiq/web_api_extension_test.rb
+++ b/test/test_sidekiq/web_api_extension_test.rb
@@ -61,10 +61,10 @@ module Sidekiq
       end
     end
 
-    describe 'GET /api/statistic_by_state.json' do
+    describe 'GET /api/statistic_by_last_job_status.json' do
       describe 'without jobs' do
         it 'returns empty workers statistic' do
-          get '/api/statistic_by_state.json'
+          get '/api/statistic_by_last_job_status.json'
 
           response = Sidekiq.load_json(last_response.body)
           _(response['status']).must_be_instance_of Hash
@@ -76,7 +76,7 @@ module Sidekiq
       describe 'for perfomed jobs' do
         it 'returns workers statistic filtered by state' do
           middlewared {}
-          get '/api/statistic_by_state.json'
+          get '/api/statistic_by_last_job_status.json'
 
           response = Sidekiq.load_json(last_response.body)
           _(response['status']).must_be_instance_of Hash
@@ -94,7 +94,7 @@ module Sidekiq
 
         describe 'for date range with empty statistic' do
           it 'returns empty statistic' do
-            get '/api/statistic_by_state.json?dateFrom=2015-07-28&dateTo=2015-07-29'
+            get '/api/statistic_by_last_job_status.json?dateFrom=2015-07-28&dateTo=2015-07-29'
 
             response = Sidekiq.load_json(last_response.body)
             _(response['status']).must_be_instance_of Hash
@@ -105,7 +105,7 @@ module Sidekiq
 
         describe 'for any date range with existed statistic' do
           it 'returns workers statistic filtered by state' do
-            get "/api/statistic_by_state.json?dateFrom=2015-07-28&dateTo=#{Date.today}"
+            get "/api/statistic_by_last_job_status.json?dateFrom=2015-07-28&dateTo=#{Date.today}"
 
             response = Sidekiq.load_json(last_response.body)
             _(response['status']).must_be_instance_of Hash


### PR DESCRIPTION
Added a way to filter workers by their last_job_status properties (as requested in #113) both in the API and in the statistics web page. Tests for the API and the called methods are also included.

### API:
- Added a new endpoint: `/sidekiq/api/statistic_by_last_job_status.json`
- It returns a JSON object with the following template:
```
{
  "status": {
    "passed": [worker_array...],
    "failed": [worker_array...]
  }
}
```

### Web page
In `/sidekiq/statistic` Worker's table I added two checkboxes (Passed and Failed) to show/hide the workers in the table depending on their last job status.