### PR TITLE
[#174] Adding support to i18n in Datepickers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD
 
+## v1.6.0
+
+* 14.02.2021: Improve filter capabilities (add i18n support) (#174) *Wender Freese*
+
 ## v1.5.1
 
 * 06.02.2021: Generate new TAG to fix "version.rb" not updated in the previous one (#170) *Wender Freese*

--- a/lib/sidekiq/statistic.rb
+++ b/lib/sidekiq/statistic.rb
@@ -9,6 +9,7 @@ end
 require 'sidekiq/api'
 require 'sidekiq/statistic/configuration'
 require 'sidekiq/statistic/log_parser'
+require 'sidekiq/statistic/statistic/filter'
 require 'sidekiq/statistic/statistic/metric'
 require 'sidekiq/statistic/statistic/metrics/cache_keys'
 require 'sidekiq/statistic/statistic/metrics/store'

--- a/lib/sidekiq/statistic/helpers/date.rb
+++ b/lib/sidekiq/statistic/helpers/date.rb
@@ -4,22 +4,24 @@ module Sidekiq
   module Statistic
     module Helpers
       module Date
-        DEFAULT_DAYS = 20
-
         def format_date(date_to_format, format = nil)
           time = date_to_format ? convert_to_date_object(date_to_format) : Time.now
           time.strftime(date_format(format))
         end
 
-        def calculate_date_range(params)
-          if params['dateFrom'] && params['dateTo']
-            from = ::Date.parse(params['dateFrom'])
-            to   = ::Date.parse(params['dateTo'])
+        def build_filter_from_request
+          from = params['dateFrom']
+          to = params['dateTo']
 
-            [(to - from).to_i, to]
-          else
-            [DEFAULT_DAYS]
-          end
+          Filter.new(from: from, to: to)
+        end
+
+        def from
+          (::Date.today - Filter::DEFAULT_DAYS_TO_RANGE).strftime(date_format)
+        end
+
+        def to
+          (::Date.today).strftime(date_format)
         end
 
         module_function

--- a/lib/sidekiq/statistic/locales/pt-br.yml
+++ b/lib/sidekiq/statistic/locales/pt-br.yml
@@ -13,7 +13,7 @@ pt-br: # <---- change this to your locale code
   WorkersTable: Tabela de Workers
   Worker: Worker
   Date: Data
-  Success: Successo
+  Success: Sucesso
   Failure: Falha
   Total: Total
   TimeSec: Tempo(s)
@@ -32,3 +32,5 @@ pt-br: # <---- change this to your locale code
     formats:
       default: "%d/%m/%Y"
       datetime: "%d/%m/%Y - %T"
+      picker:
+        default: "dd/mm/yy"

--- a/lib/sidekiq/statistic/statistic/filter.rb
+++ b/lib/sidekiq/statistic/statistic/filter.rb
@@ -6,7 +6,7 @@ module Sidekiq
       DEFAULT_DAYS_TO_RANGE = 30
       DEFAULT_DATE_FORMAT = '%Y-%m-%d'
 
-      def self.month
+      def self.past_thirty_days
         new(from: nil, to: nil)
       end
 

--- a/lib/sidekiq/statistic/statistic/filter.rb
+++ b/lib/sidekiq/statistic/statistic/filter.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Sidekiq
+  module Statistic
+    class Filter
+      DEFAULT_DAYS_TO_RANGE = 30
+      DEFAULT_DATE_FORMAT = '%Y-%m-%d'
+
+      def self.month
+        new(from: nil, to: nil)
+      end
+
+      def self.yesterday
+        new(from: nil, to: nil, days_to_return: 1)
+      end
+
+      def initialize(from:, to:, days_to_return: DEFAULT_DAYS_TO_RANGE)
+        @from = from ? ::Date.parse(from) : today - days_to_return
+        @to = to ? ::Date.parse(to) : today
+      end
+
+      def range
+        (from..to).map { |date| date.strftime DEFAULT_DATE_FORMAT }
+      end
+
+      private
+
+      attr_reader :from, :to
+
+      def today
+        @today ||= Time.now.utc.to_date
+      end
+    end
+  end
+end

--- a/lib/sidekiq/statistic/statistic/realtime.rb
+++ b/lib/sidekiq/statistic/statistic/realtime.rb
@@ -10,7 +10,7 @@ module Sidekiq
       end
 
       def initialize
-        super Filter.month
+        super Filter.past_thirty_days
       end
 
       def realtime_hash

--- a/lib/sidekiq/statistic/statistic/realtime.rb
+++ b/lib/sidekiq/statistic/statistic/realtime.rb
@@ -3,8 +3,6 @@
 module Sidekiq
   module Statistic
     class Realtime < Base
-      DAYS_PREVIOUS = 30
-
       def self.charts_initializer
         workers = new.worker_names.map{ |w| Array.new(12, 0).unshift(w) }
         workers << Array.new(12) { |i| (Time.now - i).strftime('%T') }.unshift('x')
@@ -12,8 +10,7 @@ module Sidekiq
       end
 
       def initialize
-        @start_date = Time.now.utc.to_date
-        @end_date = @start_date - DAYS_PREVIOUS
+        super Filter.month
       end
 
       def realtime_hash

--- a/lib/sidekiq/statistic/views/statistic.erb
+++ b/lib/sidekiq/statistic/views/statistic.erb
@@ -8,6 +8,8 @@
 <script type="text/javascript" src="<%= root_path %>c3.js"></script>
 <script type="text/javascript" src="<%= root_path %>statistic.js"></script>
 
+<input type="hidden" id="i18n.formats.date" name="i18n.formats.date" value="<%= get_locale.dig('date', 'formats', 'picker', 'default') %>" />
+
 <div class="statistic">
   <h2><%= t('Statistic') %></h2>
 
@@ -21,10 +23,12 @@
       <div>
         <label><%= t('Start') %></label>
         <input id="datepicker_from" class="statistic__datepicker__input left" autocomplete="off" />
+        <input type="hidden" id="datepicker_from_init_val" value="<%= from %>" />
       </div>
       <div>
         <label><%= t('End') %></label>
         <input id="datepicker_to" class="statistic__datepicker__input right" autocomplete="off" />
+        <input type="hidden" id="datepicker_to_init_val" value="<%= to %>" />
       </div>
     </div>
 
@@ -56,7 +60,7 @@
           <td>
             <a href="<%= root_path %>statistic/<%= worker[:name] %>"><%= worker[:name] %></a>
           </td>
-          <td><%= format_date worker[:runtime][:last], 'datetime' %></td>
+          <td><%= format_date worker[:runtime][:last] %></td>
           <td><%= worker[:queue] %></td>
           <td><%= worker[:number_of_calls][:success] %></td>
           <td><%= worker[:number_of_calls][:failure] %></td>

--- a/lib/sidekiq/statistic/views/statistic.js
+++ b/lib/sidekiq/statistic/views/statistic.js
@@ -11,10 +11,12 @@
 else{for(c=i&&i.getFullYear()===a,o=s&&s.getFullYear()===a,y+="<select class='ui-datepicker-month' data-handler='selectMonth' data-event='change'>",l=0;12>l;l++)(!c||l>=i.getMonth())&&(!o||l<=s.getMonth())&&(y+="<option value='"+l+"'"+(l===t?" selected='selected'":"")+">"+d[l]+"</option>");y+="</select>"}if(m||(D+=y+(!r&&k&&f?"":"&#xa0;")),!e.yearshtml)if(e.yearshtml="",r||!f)D+="<span class='ui-datepicker-year'>"+a+"</span>";else{for(h=this._get(e,"yearRange").split(":"),u=(new Date).getFullYear(),p=function(e){var t=e.match(/c[+\-].*/)?a+parseInt(e.substring(1),10):e.match(/[+\-].*/)?u+parseInt(e,10):parseInt(e,10);return isNaN(t)?u:t},g=p(h[0]),_=Math.max(g,p(h[1]||"")),g=i?Math.max(g,i.getFullYear()):g,_=s?Math.min(_,s.getFullYear()):_,e.yearshtml+="<select class='ui-datepicker-year' data-handler='selectYear' data-event='change'>";_>=g;g++)e.yearshtml+="<option value='"+g+"'"+(g===a?" selected='selected'":"")+">"+g+"</option>";e.yearshtml+="</select>",D+=e.yearshtml,e.yearshtml=null}return D+=this._get(e,"yearSuffix"),m&&(D+=(!r&&k&&f?"":"&#xa0;")+y),D+="</div>"},_adjustInstDate:function(e,t,a){var i=e.drawYear+("Y"===a?t:0),s=e.drawMonth+("M"===a?t:0),r=Math.min(e.selectedDay,this._getDaysInMonth(i,s))+("D"===a?t:0),n=this._restrictMinMax(e,this._daylightSavingAdjust(new Date(i,s,r)));e.selectedDay=n.getDate(),e.drawMonth=e.selectedMonth=n.getMonth(),e.drawYear=e.selectedYear=n.getFullYear(),("M"===a||"Y"===a)&&this._notifyChange(e)},_restrictMinMax:function(e,t){var a=this._getMinMaxDate(e,"min"),i=this._getMinMaxDate(e,"max"),s=a&&a>t?a:t;return i&&s>i?i:s},_notifyChange:function(e){var t=this._get(e,"onChangeMonthYear");t&&t.apply(e.input?e.input[0]:null,[e.selectedYear,e.selectedMonth+1,e])},_getNumberOfMonths:function(e){var t=this._get(e,"numberOfMonths");return null==t?[1,1]:"number"==typeof t?[1,t]:t},_getMinMaxDate:function(e,t){return this._determineDate(e,this._get(e,t+"Date"),null)},_getDaysInMonth:function(e,t){return 32-this._daylightSavingAdjust(new Date(e,t,32)).getDate()},_getFirstDayOfMonth:function(e,t){return new Date(e,t,1).getDay()},_canAdjustMonth:function(e,t,a,i){var s=this._getNumberOfMonths(e),r=this._daylightSavingAdjust(new Date(a,i+(0>t?t:s[0]*s[1]),1));return 0>t&&r.setDate(this._getDaysInMonth(r.getFullYear(),r.getMonth())),this._isInRange(e,r)},_isInRange:function(e,t){var a,i,s=this._getMinMaxDate(e,"min"),r=this._getMinMaxDate(e,"max"),n=null,d=null,c=this._get(e,"yearRange");return c&&(a=c.split(":"),i=(new Date).getFullYear(),n=parseInt(a[0],10),d=parseInt(a[1],10),a[0].match(/[+\-].*/)&&(n+=i),a[1].match(/[+\-].*/)&&(d+=i)),(!s||t.getTime()>=s.getTime())&&(!r||t.getTime()<=r.getTime())&&(!n||t.getFullYear()>=n)&&(!d||t.getFullYear()<=d)},_getFormatConfig:function(e){var t=this._get(e,"shortYearCutoff");return t="string"!=typeof t?t:(new Date).getFullYear()%100+parseInt(t,10),{shortYearCutoff:t,dayNamesShort:this._get(e,"dayNamesShort"),dayNames:this._get(e,"dayNames"),monthNamesShort:this._get(e,"monthNamesShort"),monthNames:this._get(e,"monthNames")}},_formatDate:function(e,t,a,i){t||(e.currentDay=e.selectedDay,e.currentMonth=e.selectedMonth,e.currentYear=e.selectedYear);var s=t?"object"==typeof t?t:this._daylightSavingAdjust(new Date(i,a,t)):this._daylightSavingAdjust(new Date(e.currentYear,e.currentMonth,e.currentDay));return this.formatDate(this._get(e,"dateFormat"),s,this._getFormatConfig(e))}}),e.fn.datepicker=function(t){if(!this.length)return this;e.datepicker.initialized||(e(document).mousedown(e.datepicker._checkExternalClick),e.datepicker.initialized=!0),0===e("#"+e.datepicker._mainDivId).length&&e("body").append(e.datepicker.dpDiv);var a=Array.prototype.slice.call(arguments,1);return"string"!=typeof t||"isDisabled"!==t&&"getDate"!==t&&"widget"!==t?"option"===t&&2===arguments.length&&"string"==typeof arguments[1]?e.datepicker["_"+t+"Datepicker"].apply(e.datepicker,[this[0]].concat(a)):this.each(function(){"string"==typeof t?e.datepicker["_"+t+"Datepicker"].apply(e.datepicker,[this].concat(a)):e.datepicker._attachDatepicker(this,t)}):e.datepicker["_"+t+"Datepicker"].apply(e.datepicker,[this[0]].concat(a))},e.datepicker=new a,e.datepicker.initialized=!1,e.datepicker.uuid=(new Date).getTime(),e.datepicker.version="@VERSION",e.datepicker});
 
 $(function () {
+  (function() {
+    initializeDatePickers()
 
-  var datePickerFrom, datePickerTo
-
-  initializeDatePickers()
+    $("#datepicker_from").datepicker('setDate', $("#datepicker_from_init_val").val())
+    $("#datepicker_to").datepicker('setDate', $("#datepicker_to_init_val").val())
+  })()
 
   if (isHaveCharts()) { initializeChars({}) }
 
@@ -68,30 +70,27 @@ $(function () {
   }
 
   function initializeDatePickers() {
+    var format = $('input[id="i18n.formats.date"]').val()
+
     $('#datepicker_from').datepicker({
-      dateFormat: 'dd-mm-yy',
+      dateFormat: format,
       firstDay: 1,
       maxDate: -1,
-      onSelect: function (selected) {
-        datePickerFrom = selected
-        $("#datepicker_to").datepicker("option","minDate", selected)
-        rerenderPage()
-      }
+      onSelect: function () { rerenderPage() }
     })
 
     $('#datepicker_to').datepicker({
-      dateFormat: 'dd-mm-yy',
+      dateFormat: format,
       firstDay: 1,
       maxDate: 0,
-      onSelect: function (selected) {
-        datePickerTo = selected
-        $("#datepicker_from").datepicker("option","maxDate", selected)
-        rerenderPage()
-      }
+      onSelect: function () { rerenderPage() }
     })
   }
 
   function rerenderPage() {
+    var datePickerFrom = $("#datepicker_from").datepicker('getDate')
+    var datePickerTo = $("#datepicker_to").datepicker('getDate')
+
     if (datePickerFrom && datePickerTo) {
       var requestData = {
         dateFrom: datePickerFrom,
@@ -105,10 +104,8 @@ $(function () {
       $(document).ajaxComplete(function() {
         initializeDatePickers()
 
-        $('#datepicker_from').datepicker('option','maxDate', datePickerTo)
-        $('#datepicker_from').datepicker('setDate', datePickerFrom)
-        $('#datepicker_to').datepicker('option','minDate', datePickerFrom)
-        $('#datepicker_to').datepicker('setDate', datePickerTo)
+        $("#datepicker_from").datepicker('setDate', datePickerFrom)
+        $("#datepicker_to").datepicker('setDate', datePickerTo)
       })
     }
   }

--- a/lib/sidekiq/statistic/views/worker.erb
+++ b/lib/sidekiq/statistic/views/worker.erb
@@ -1,12 +1,14 @@
 <% add_to_head do %>
   <link href="<%= root_path %>common.css" media="screen" rel="stylesheet" type="text/css" />
   <link href="<%= root_path %>ui-datepicker.css" media="screen" rel="stylesheet" type="text/css" />
-  
+
   <link href="<%= root_path %>sidekiq-statistic-light.css" media="screen and (prefers-color-scheme: light)" rel="stylesheet" type="text/css" />
   <link href="<%= root_path %>sidekiq-statistic-dark.css" media="screen and (prefers-color-scheme: dark)" rel="stylesheet" type="text/css" />
 <% end %>
 
 <script type="text/javascript" src="<%= root_path %>statistic.js"></script>
+
+<input type="hidden" id="i18n.formats.date" name="i18n.formats.date" value="<%= get_locale.dig('date', 'formats', 'picker', 'default') %>" />
 
 <div class='statistic'>
   <h2><%= t('WorkerInformation', worker: @name) %></h2>
@@ -21,10 +23,12 @@
       <div>
         <label><%= t('Start') %></label>
         <input id="datepicker_from" class="statistic__datepicker__input left" autocomplete="off" />
+        <input type="hidden" id="datepicker_from_init_val" value="<%= from %>" />
       </div>
       <div>
         <label><%= t('End') %></label>
         <input id="datepicker_to" class="statistic__datepicker__input right" autocomplete="off" />
+        <input type="hidden" id="datepicker_to_init_val" value="<%= to %>" />
       </div>
     </div>
 

--- a/lib/sidekiq/statistic/web_api_extension.rb
+++ b/lib/sidekiq/statistic/web_api_extension.rb
@@ -14,14 +14,14 @@ module Sidekiq
         end
 
         app.get '/api/statistic.json' do
-          statistic = Sidekiq::Statistic::Workers.new(*calculate_date_range(params))
+          statistic = Sidekiq::Statistic::Workers.new(build_filter_from_request)
           Sidekiq.dump_json(workers: statistic.display)
         end
 
         app.get '/api/statistic/:worker.json' do
           worker_statistic =
             Sidekiq::Statistic::Workers
-              .new(*calculate_date_range(params))
+              .new(build_filter_from_request)
               .display_per_day(params[:worker])
 
           Sidekiq.dump_json(days: worker_statistic)

--- a/lib/sidekiq/statistic/web_extension.rb
+++ b/lib/sidekiq/statistic/web_extension.rb
@@ -44,15 +44,15 @@ module Sidekiq
         end
 
         app.get '/statistic' do
-          statistic = Workers.new(*calculate_date_range(params))
-          
+          statistic = Workers.new(build_filter_from_request)
+
           @all_workers = statistic.display
 
           render(:erb, Views.require_assets('statistic.erb').first)
         end
 
         app.get '/statistic/charts.json' do
-          charts = Charts.new(*calculate_date_range(params))
+          charts = Charts.new(build_filter_from_request)
           date = {
             format: date_format,
             labels: charts.dates
@@ -66,8 +66,10 @@ module Sidekiq
         end
 
         app.get '/statistic/realtime' do
-          @workers = Realtime.new.worker_names
-          
+          @workers = Realtime
+            .new
+            .worker_names
+
           render(:erb, Views.require_assets('realtime.erb').first)
         end
 
@@ -84,7 +86,7 @@ module Sidekiq
         app.get '/statistic/:worker' do
           @name = params[:worker]
 
-          @worker_statistic = Workers.new(*calculate_date_range(params))
+          @worker_statistic = Workers.new(build_filter_from_request)
                                      .display_per_day(@name)
           @worker_log = LogParser.new(@name).parse
 

--- a/test/statistic/filter_test.rb
+++ b/test/statistic/filter_test.rb
@@ -3,37 +3,37 @@
 require 'minitest_helper'
 
 describe Sidekiq::Statistic::Filter do
-	describe '.past_thirty_days' do
-		it 'assigns correct "from" and "to" dates' do
-			travel_to Time.new(2021, 1, 31, 14, 00, 00) do
-	      result = Sidekiq::Statistic::Filter.past_thirty_days
+  describe '.past_thirty_days' do
+    it 'assigns correct "from" and "to" dates' do
+      travel_to Time.new(2021, 1, 31, 14, 00, 00) do
+        result = Sidekiq::Statistic::Filter.past_thirty_days
 
-	      # Reading instance variables directly only for test purpose
-	      assert_equal result.instance_variable_get(:@from).to_s, '2021-01-01'
-	      assert_equal result.instance_variable_get(:@to).to_s, '2021-01-31'
-	    end
+        # Reading instance variables directly only for test purpose
+        assert_equal result.instance_variable_get(:@from).to_s, '2021-01-01'
+        assert_equal result.instance_variable_get(:@to).to_s, '2021-01-31'
+      end
     end
-	end
+  end
 
-	describe '.yesterday' do
-		it 'assigns correct "from" and "to" dates' do
-			travel_to Time.new(2021, 1, 31, 14, 00, 00) do
-	      result = Sidekiq::Statistic::Filter.yesterday
+  describe '.yesterday' do
+    it 'assigns correct "from" and "to" dates' do
+      travel_to Time.new(2021, 1, 31, 14, 00, 00) do
+        result = Sidekiq::Statistic::Filter.yesterday
 
-	      # Reading instance variables directly only for test purpose
-	      assert_equal result.instance_variable_get(:@from).to_s, '2021-01-30'
-	      assert_equal result.instance_variable_get(:@to).to_s, '2021-01-31'
-	    end
+        # Reading instance variables directly only for test purpose
+        assert_equal result.instance_variable_get(:@from).to_s, '2021-01-30'
+        assert_equal result.instance_variable_get(:@to).to_s, '2021-01-31'
+      end
     end
-	end
+  end
 
-	describe '#range' do
-		it 'assigns correct "from" and "to" dates' do
-			travel_to Time.new(2021, 1, 31, 14, 00, 00) do
-	      result = Sidekiq::Statistic::Filter.yesterday.range
+  describe '#range' do
+    it 'assigns correct "from" and "to" dates' do
+      travel_to Time.new(2021, 1, 31, 14, 00, 00) do
+        result = Sidekiq::Statistic::Filter.yesterday.range
 
-	      assert_equal result, %w[2021-01-30 2021-01-31]
-	    end
+        assert_equal result, %w[2021-01-30 2021-01-31]
+      end
     end
-	end
+  end
 end

--- a/test/statistic/filter_test.rb
+++ b/test/statistic/filter_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'minitest_helper'
+
+describe Sidekiq::Statistic::Filter do
+	describe '.past_thirty_days' do
+		it 'assigns correct "from" and "to" dates' do
+			travel_to Time.new(2021, 1, 31, 14, 00, 00) do
+	      result = Sidekiq::Statistic::Filter.past_thirty_days
+
+	      # Reading instance variables directly only for test purpose
+	      assert_equal result.instance_variable_get(:@from).to_s, '2021-01-01'
+	      assert_equal result.instance_variable_get(:@to).to_s, '2021-01-31'
+	    end
+    end
+	end
+
+	describe '.yesterday' do
+		it 'assigns correct "from" and "to" dates' do
+			travel_to Time.new(2021, 1, 31, 14, 00, 00) do
+	      result = Sidekiq::Statistic::Filter.yesterday
+
+	      # Reading instance variables directly only for test purpose
+	      assert_equal result.instance_variable_get(:@from).to_s, '2021-01-30'
+	      assert_equal result.instance_variable_get(:@to).to_s, '2021-01-31'
+	    end
+    end
+	end
+
+	describe '#range' do
+		it 'assigns correct "from" and "to" dates' do
+			travel_to Time.new(2021, 1, 31, 14, 00, 00) do
+	      result = Sidekiq::Statistic::Filter.yesterday.range
+
+	      assert_equal result, %w[2021-01-30 2021-01-31]
+	    end
+    end
+	end
+end

--- a/test/test_sidekiq/base_statistic_test.rb
+++ b/test/test_sidekiq/base_statistic_test.rb
@@ -7,7 +7,8 @@ module Sidekiq
     describe 'Base' do
       before { Sidekiq.redis(&:flushdb) }
 
-      let(:base_statistic) { Sidekiq::Statistic::Base.new(1) }
+      let(:filter) { Sidekiq::Statistic::Filter.yesterday }
+      let(:base_statistic) { Sidekiq::Statistic::Base.new(filter) }
 
       describe '#redis_hash' do
         it 'returns hash for each day' do

--- a/test/test_sidekiq/charts_test.rb
+++ b/test/test_sidekiq/charts_test.rb
@@ -7,7 +7,7 @@ module Sidekiq
     describe 'Charts' do
       before { Sidekiq.redis(&:flushdb) }
 
-      let(:filter) { Sidekiq::Statistic::Filter.month }
+      let(:filter) { Sidekiq::Statistic::Filter.past_thirty_days }
       let(:chart) { Sidekiq::Statistic::Charts.new(filter) }
 
       describe '#dates' do

--- a/test/test_sidekiq/charts_test.rb
+++ b/test/test_sidekiq/charts_test.rb
@@ -7,7 +7,8 @@ module Sidekiq
     describe 'Charts' do
       before { Sidekiq.redis(&:flushdb) }
 
-      let(:chart) { Sidekiq::Statistic::Charts.new(1) }
+      let(:filter) { Sidekiq::Statistic::Filter.month }
+      let(:chart) { Sidekiq::Statistic::Charts.new(filter) }
 
       describe '#dates' do
         it 'returns array with all days' do

--- a/test/test_sidekiq/helpers/date_test.rb
+++ b/test/test_sidekiq/helpers/date_test.rb
@@ -42,21 +42,13 @@ module Sidekiq
       end
     end
 
-    describe '.calculate_date_range' do
-      let(:helper_date) { Helper.new({}, {}) }
+    describe '.build_filter_from_request' do
+      let(:clazz) { Helper.new({}, {}) }
 
-      it 'returns the range between dates' do
-        diference = 2
-        today = Date.new
-        two_days_ago = today - diference
-        params = { 'dateFrom' => two_days_ago.to_s,
-                   'dateTo' => today.to_s }
-
-        _(helper_date.calculate_date_range(params)).must_equal([diference, today])
-      end
-
-      it 'returns default range' do
-        _(helper_date.calculate_date_range({})).must_equal([20])
+      it 'returns Filter instance with correct data' do
+        helper_date.stub :params, { 'dateFrom' => '2021-02-13T10:15:00', 'dateTo' => '2021-02-14T10:15:00' } do
+          assert_equal helper_date.build_filter_from_request.range, %w[2021-02-13 2021-02-14]
+        end
       end
     end
   end

--- a/test/test_sidekiq/runtime_test.rb
+++ b/test/test_sidekiq/runtime_test.rb
@@ -7,7 +7,8 @@ module Sidekiq
     describe 'Runtime' do
       before { Sidekiq.redis(&:flushdb) }
 
-      let(:statistic)         { Sidekiq::Statistic::Base.new(1) }
+      let(:filter) { Sidekiq::Statistic::Filter.yesterday }
+      let(:statistic) { Sidekiq::Statistic::Base.new(filter) }
       let(:runtime_statistic) { Sidekiq::Statistic::Runtime.new(statistic, 'HistoryWorker') }
 
       describe '#last_runtime' do

--- a/test/test_sidekiq/statistic_test.rb
+++ b/test/test_sidekiq/statistic_test.rb
@@ -7,8 +7,9 @@ module Sidekiq
     describe 'Workers' do
       before { Sidekiq.redis(&:flushdb) }
 
-      let(:statistic) { Sidekiq::Statistic::Workers.new(1) }
-      let(:base_statistic) { Sidekiq::Statistic::Base.new(1) }
+      let(:filter) { Sidekiq::Statistic::Filter.yesterday }
+      let(:statistic) { Sidekiq::Statistic::Workers.new(filter) }
+      let(:base_statistic) { Sidekiq::Statistic::Base.new(filter) }
       let(:worker) { 'HistoryWorker' }
 
       describe '#number_of_calls' do


### PR DESCRIPTION
Related to: https://github.com/davydovanton/sidekiq-statistic/issues/174

### Changes

- Add support to i18n in Datepickers to present dates in the same format the other places present
- In the worker's table, I removed the "time" from the date column once we're presenting workers by day at this point, not exactly the time

### Motivation

- Improve UX

### Results

### Input i18n
#### Before
![image](https://user-images.githubusercontent.com/941776/107884982-7af70d80-6ed6-11eb-8104-bf5659eb0312.png)

#### After
![image](https://user-images.githubusercontent.com/941776/107885049-bc87b880-6ed6-11eb-85ae-f50bc471a61d.png)


### Workers table without time on Date column
#### Before

![image](https://user-images.githubusercontent.com/941776/107885112-2c963e80-6ed7-11eb-9789-c56cf197f617.png)


#### After

![image](https://user-images.githubusercontent.com/941776/107885080-f062de00-6ed6-11eb-87cd-a36a17adbb77.png)
