### PR TITLE
Fix jQuery missing issues for newer Sidekiq versions

### DIFF
--- a/lib/sidekiq/statistic/views/realtime_statistic.js
+++ b/lib/sidekiq/statistic/views/realtime_statistic.js
@@ -1,7 +1,7 @@
 const BASEURL = window.location.pathname;
 
 const requestJSON = (url, config) =>
-  $.ajax(
+  fetch(
     `${BASEURL}/${url}`,
     {
       dataType: "json",
@@ -44,8 +44,12 @@ const Elements = {
 }
 
 const Listeners = {
-  toggleVisibilityButton: () => $(Elements.toggleVisibilityButton).click(toggleWorkerVisibility),
-  realtimeToggleButton: () => $(Elements.realtimeToggleButton).click(toggleRealTime)
+  toggleVisibilityButton: function() {
+    document.querySelector(Elements.toggleVisibilityButton).addEventListener('click', toggleWorkerVisibility)
+  },
+  realtimeToggleButton: function() {
+    document.querySelector(Elements.realtimeToggleButton).addEventListener('click', toggleRealTime)
+  },
 }
 
 class ChartsUpdateService {
@@ -67,11 +71,12 @@ const initialize = () => {
 
 const initializeCharts = () => {
   requestJSON(Charts.paths.init)
-    .done(function (response) {
+    .then(response => response.json())
+    .then(function (response) {
       const options = Charts.options(response);
 
-      Data.failedChart = c3.generate($.extend(options, { bindto: '.realtime__failed-chart' }));
-      Data.passedChart = c3.generate($.extend(options, { bindto: '.realtime__passed-chart' }));
+      Data.failedChart = c3.generate({ ...options, ...{ bindto: '.realtime__failed-chart' } });
+      Data.passedChart = c3.generate({ ...options, ...{ bindto: '.realtime__passed-chart' } });
 
       ChartsUpdateService.start()
     })
@@ -83,17 +88,18 @@ const setEventListeners = () => {
   })
 }
 
-function toggleWorkerVisibility() {
-  const toggleWorkerButton = $(this)
+function toggleWorkerVisibility(event) {
+  const toggleWorkerButton = event.target
   const { name } = this
 
-  const visibilityIcon = toggleWorkerButton.find('.worker__visibility-icon')
-  const currentStatus = toggleWorkerButton.data('visible')
-  const visible = !currentStatus
-
-  visibilityIcon.toggleClass(`${visibilityStatusClasses[currentStatus]} ${visibilityStatusClasses[visible]}`)
-
-  toggleWorkerButton.data('visible', visible)
+  const currentStatus = toggleWorkerButton.dataset.visible;
+  const visible = !currentStatus;
+  const visibilityIcon = toggleWorkerButton.querySelector('.worker__visibility-icon');
+  if(visibilityIcon) {
+    visibilityIcon.classList.toggle(visibilityStatusClasses[currentStatus]);
+    visibilityIcon.classList.toggle(visibilityStatusClasses[visible]);
+  }
+  toggleWorkerButton.dataset.visible = visible;
 
   Data.failedChart.toggle(name)
   Data.passedChart.toggle(name)
@@ -101,13 +107,12 @@ function toggleWorkerVisibility() {
   if (!visible) {
     Data.excludedWorkers.push(this.name)
   } else {
-    Data.excludedWorkers.splice($.inArray(this.name, Data.excludedWorkers), 1)
+    Data.excludedWorkers.splice(Data.excludedWorkers.indexOf(this.name), 1)
   }
 }
 
-function toggleRealTime() {
-  const toggleRealtimeButton = $(this)
-
+function toggleRealTime(event) {
+  const toggleRealtimeButton = event.target;
   const { start, stop, started } = toggleRealtimeButton.data();
 
   const buttonText = {
@@ -117,7 +122,7 @@ function toggleRealTime() {
 
   const toggleButton = value => {
     toggleRealtimeButton.text(buttonText[value])
-    toggleRealtimeButton.data('started', value)
+    toggleRealtimeButton.dataset.started = value
   }
 
   if (started) {
@@ -136,9 +141,9 @@ const visibilityStatusClasses = {
 }
 
 const noVisibleWorkers = () =>
-  $(Elements.toggleVisibilityButton)
-    .get()
-    .every(element => $(element).data('visible') === false)
+  Array
+    .from(document.querySelectorAll(Elements.toggleVisibilityButton))
+    .every(element => element.dataset.visible === false)
 
 const updateCharts = () => {
   if (noVisibleWorkers()) {
@@ -146,10 +151,16 @@ const updateCharts = () => {
   }
 
   requestJSON(Charts.paths.realtime, { data: { excluded: Data.excludedWorkers } })
-    .done(function (data) {
+    .then(response => response.json())
+    .then(function (data) {
       Data.failedChart.flow(data['failed'])
       Data.passedChart.flow(data['passed'])
     })
 }
 
-$(initialize);
+const docReady = (callback) => {
+  if (document.readyState !== "loading") callback();
+  else document.addEventListener("DOMContentLoaded", callback);
+}
+
+docReady(() => initialize());

--- a/lib/sidekiq/statistic/views/statistic.erb
+++ b/lib/sidekiq/statistic/views/statistic.erb
@@ -3,6 +3,7 @@
   <link href="<%= root_path %>ui-datepicker.css" media="screen" rel="stylesheet" type="text/css" />
   <link href="<%= root_path %>sidekiq-statistic-light.css" media="screen and (prefers-color-scheme: light)" rel="stylesheet" type="text/css" />
   <link href="<%= root_path %>sidekiq-statistic-dark.css" media="screen and (prefers-color-scheme: dark)" rel="stylesheet" type="text/css" />
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
 <% end %>
 
 <script type="text/javascript" src="<%= root_path %>c3.js"></script>

--- a/lib/sidekiq/statistic/views/statistic.erb
+++ b/lib/sidekiq/statistic/views/statistic.erb
@@ -3,7 +3,10 @@
   <link href="<%= root_path %>ui-datepicker.css" media="screen" rel="stylesheet" type="text/css" />
   <link href="<%= root_path %>sidekiq-statistic-light.css" media="screen and (prefers-color-scheme: light)" rel="stylesheet" type="text/css" />
   <link href="<%= root_path %>sidekiq-statistic-dark.css" media="screen and (prefers-color-scheme: dark)" rel="stylesheet" type="text/css" />
-  <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
+  <% if Sidekiq::VERSION >= '6.3' %>
+    <!-- Jquery was removed in Sidekiq 6.3, so we need to explicitly add it. Several components (e.g. datepicker) require it -->
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
+  <% end %>
 <% end %>
 
 <script type="text/javascript" src="<%= root_path %>c3.js"></script>

--- a/lib/sidekiq/statistic/views/worker.erb
+++ b/lib/sidekiq/statistic/views/worker.erb
@@ -1,7 +1,6 @@
 <% add_to_head do %>
   <link href="<%= root_path %>common.css" media="screen" rel="stylesheet" type="text/css" />
   <link href="<%= root_path %>ui-datepicker.css" media="screen" rel="stylesheet" type="text/css" />
-  
   <link href="<%= root_path %>sidekiq-statistic-light.css" media="screen and (prefers-color-scheme: light)" rel="stylesheet" type="text/css" />
   <link href="<%= root_path %>sidekiq-statistic-dark.css" media="screen and (prefers-color-scheme: dark)" rel="stylesheet" type="text/css" />
 <% end %>


### PR DESCRIPTION
First of all, let me say that I really love this gem, its super neat! :100: 

I do have some trouble using it at the moment, however. When using `sidekiq-statistic` with Sidekiq 6.3 or later, it will be broken, as Sidekiq itself no longer ships with jQuery (see [Changelog](https://github.com/mperham/sidekiq/blob/main/Changes.md#630)). This was also brought up in #180. 

## Reproducing

Add `sidekiq` 6.3 or later and `sidekiq-statistic` to your gem file. Open the Sidekiq UI, head to the Statistic tab and observe errors in the console. Functionality such as graphs, polling or date picker will not work. 

## Fix

First, because it was doable, `realtime_statistic.js` was moved off jQuery by replacing it with plain JS. If Sidekiq can do it, so can we! :stuck_out_tongue: 

Unfortunately, doing the same for `statistic.js` was not really feasible, as that would mean adding a new date picker and so on, and that is kind of a big change. Instead, I opted for loading Sidekiq from a CDN _only_ if Sidekiq 6.3 or later is used. 

Let me know if you need any additional changes. I'd be happy to open any follow up PRs to also move `statistic.js` away from jQuery, if you have any ideas there :slightly_smiling_face: 

