### PR TITLE
Migrate CI to GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: build
+
+on: [pull_request, push]
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '3.1'
+          - '3.0'
+          - '2.7'
+          - '2.6'
+          - '2.5'
+          - ruby-head
+          - jruby-head
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+    - run: bundle exec rake
+
+    services:
+      redis:
+        image: redis:alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379

--- a/sidekiq-statistic.gemspec
+++ b/sidekiq-statistic.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'sidekiq', '>= 5.0'
   gem.add_dependency 'tilt', '~> 2.0'
 
-  gem.add_development_dependency 'rake', '~> 0'
+  gem.add_development_dependency 'rake', '~> 13.0'
   gem.add_development_dependency 'mocha', '~> 0'
   gem.add_development_dependency 'rack-test', '~> 0'
   gem.add_development_dependency 'rack', '~> 1.6.4'


### PR DESCRIPTION
This PR migrates CI to GitHub actions.

To get CI running with `ruby-head` we update the `rake` requirement to `~> 13`