### PR TITLE
Fix Problem with Sidekiq 7

### DIFF
--- a/lib/sidekiq/statistic/statistic/metrics/store.rb
+++ b/lib/sidekiq/statistic/statistic/metrics/store.rb
@@ -19,7 +19,7 @@ module Sidekiq
           cache_length = 0
 
           Sidekiq.redis do |redis|
-            redis.pipelined { |pipeline| cache_length = store_cache_metrics(pipeline) }
+            cache_length = store_cache_metrics(redis)
             release_cache_allocation(redis, cache_length)
           end
         end
@@ -51,7 +51,7 @@ module Sidekiq
         def release_cache_allocation(redis, timelist_length)
           max_timelist_length = Sidekiq::Statistic.configuration.max_timelist_length
 
-          if timelist_length.value > max_timelist_length
+          if timelist_length > max_timelist_length
             redis.ltrim(@keys.timeslist, 0, (max_timelist_length * 0.75).to_i)
           end
         end


### PR DESCRIPTION
Due to Sidekiq 7 changes on its [Redis gem](https://github.com/mperham/sidekiq/blob/main/docs/7.0-Upgrade.md#redis-client) dependency, the behavior changed a bit. ~~Also, I'm trying to figure out if there is an [actual need to use `pipelined` ](https://github.com/redis-rb/redis-client#pipelining) flow for all those operations.~~

My goal is to maintain compatibility between Sidekiq versions: While Sidekiq 6.x uses `redis` gem, Sidekiq 7.x uses `redis-client` which is more straightforward. Sidekiq 6.x used to return a [Redis::Future](https://msp-greg.github.io/redis/Redis/Future.html) object from pipeline operations, which had to be called with `.value` method to extract the length (return of the function) of it. Now the call for the list length is always returning an Integer.

I've wrapped some calls to be pipelined, leaving the lpush out, so it directly returns an Integer.

This work relates to Issue #188 