### PR TITLE
[#saparjohnick] replace deprecated redis method hmset

### DIFF
--- a/lib/sidekiq/statistic/base.rb
+++ b/lib/sidekiq/statistic/base.rb
@@ -85,7 +85,7 @@ module Sidekiq
         statistics = time_statistics(timeslist)
 
         Sidekiq.redis do |redis|
-          redis.hmset Metrics::Store::REDIS_HASH,
+          redis.hset Metrics::Store::REDIS_HASH,
             statistics.flat_map{ |(k, v)| ["#{worker_key}:#{k}", v] }
         end
 

--- a/lib/sidekiq/statistic/statistic/metrics/store.rb
+++ b/lib/sidekiq/statistic/statistic/metrics/store.rb
@@ -30,7 +30,7 @@ module Sidekiq
           redis.pipelined do |pipeline|
             pipeline.hincrby(REDIS_HASH, @keys.status, 1)
 
-            pipeline.hmset(REDIS_HASH, @keys.last_job_status, @metric.status,
+            pipeline.hset(REDIS_HASH, @keys.last_job_status, @metric.status,
                                   @keys.last_time, @metric.finished_at.to_i,
                                   @keys.queue, @metric.queue)
 


### PR DESCRIPTION
Replacing deprecated method

`Redis has deprecated the `hmset`command, called at ["/app/vendor/bundle/ruby/3.2.0/bundler/gems/sidekiq-statistic-f27c854d317f/lib/sidekiq/statistic/statistic/metrics/store.rb:33:in `block in store_cache_metrics'"]`

https://redis.io/commands/hmset/